### PR TITLE
Allow teams as recipients for email alert rules

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -500,6 +500,7 @@
     "team_membership": "Team membership",
     "team_name": "Team Name",
     "select_team": "Select Team",
+    "select_team_as_recipient": "Select team as recipient",
     "select_permission": "Select permission",
     "password_confirm": "Confirm password",
     "user_created": "User created",

--- a/src/views/administration/notifications/Alerts.vue
+++ b/src/views/administration/notifications/Alerts.vue
@@ -32,7 +32,7 @@
   import BInputGroupFormInput from "../../../forms/BInputGroupFormInput";
   import { Switch as cSwitch } from '@coreui/vue';
 
-    export default {
+  export default {
     props: {
       header: String
     },
@@ -138,7 +138,8 @@
                                               :required="(!(this.alert.hasOwnProperty('teams') && this.alert.teams != null && this.alert.teams.length > 0)).toString()"
                                               type="text" v-model="destination" lazy="true"
                                               v-debounce:750ms="updateNotificationRule" :debounce-events="'keyup'" />
-                     <b-form-group v-if="this.publisherClass === 'org.dependencytrack.notification.publisher.SendMailPublisher'" id="teamDestinationList" :label="this.$t('admin.select_team')">
+                     <b-form-group v-if="this.publisherClass === 'org.dependencytrack.notification.publisher.SendMailPublisher'"
+                                   id="teamDestinationList" :label="this.$t('admin.select_team_as_recipient')">
                        <div class="list group">
                           <span v-for="team in teams">
                             <actionable-list-group-item :value="team.name" :delete-icon="true" v-on:actionClicked="removeSelectedTeam(team.uuid)"></actionable-list-group-item>
@@ -304,34 +305,7 @@
                     let selection = selections[i];
                     let url = `${this.$api.BASE_URL}/${this.$api.URL_NOTIFICATION_RULE}/${this.uuid}/project/${selection.uuid}`;
                     this.axios.post(url).then((response) => {
-                      if (this.projects){
-                        this.projects.push(selection);
-                      }else {
-                        this.projects = [];
-                        let project = {
-                          'author': selection.author,
-                          'publisher': selection.publisher,
-                          'group': selection.group,
-                          'name': selection.name,
-                          'description': selection.description,
-                          'version': selection.version,
-                          'classifier': selection.classifier,
-                          'cpe': selection.cpe,
-                          'purl': selection.purl,
-                          'swidTagId': selection.swidTagId,
-                          'directDependencies': selection.directDependencies,
-                          'uuid': selection.classifier,
-                          'children': selection.children,
-                          'properties': selection.properties,
-                          'tags': selection.tags,
-                          'lastBomImport': selection.lastBomImport,
-                          'lastBomImportFormat': selection.lastBomImportFormat,
-                          'lastInheritedRiskScore': selection.lastInheritedRiskScore,
-                          'active': selection.active,
-                          'metrics': selection.metrics
-                        }
-                        this.projects.push(project);
-                      }
+                      this.projects.push(selection);
                       this.$toastr.s(this.$t('message.updated'));
                     }).catch((error) => {
                       if (error.response.status === 304) {


### PR DESCRIPTION
Managing the destination of a notification rule takes a lot of time for a large group of recipients because it needs to be done manually by a user for every single recipient.

Allowing teams to be subscribed to an email alert automates this process, as every user of a subscribed team will automatically get an email without the need of inserting their email address as a destination.  

Not having to manually insert every single email address into the notification rule destination simplifies the management of notification recipients and allows dynamic email destinations by subscribing and reorganizing teams.
Individual persons can still be added as recipients if they are manually put as a destination.

Signed-off-by: RBickert <rbt@mm-software.com>