### PR TITLE
Limit alert rules to project including all existing or future versions

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -487,7 +487,7 @@
     "destination": "Destination",
     "delete_alert": "Delete Alert",
     "limit_to": "Limit To",
-    "limit_to_projects": "Limit to projects",
+    "limit_to_projects": "Limit to projects (including all of their active children)",
     "limit_to_tags": "Limit to Tags",
     "alert_created": "Alert created",
     "alert_deleted": "Alert deleted",


### PR DESCRIPTION
Change "Limit to projects" to "Limit to projects (including all of their active children)" to indicate that every child of a subscribed project will also be included in the notification rule.

Signed-off-by: RBickert <rbt@mm-software.com>