### PR TITLE
Show every depth level of dependency graph and improve readability

### DIFF
--- a/src/views/portfolio/projects/ProjectDependencyGraph.vue
+++ b/src/views/portfolio/projects/ProjectDependencyGraph.vue
@@ -303,9 +303,9 @@ export default {
   }
   // Button size and position
   .horizontal .org-tree-node-btn {
-    width: 14px;
-    height: 14px;
-    margin: -7px 0px 0px 2.85px;
+    width: 17px;
+    height: 17px;
+    margin: -9px 0px 0px 1.5px;
   }
   // Inner button vertical line
   .org-tree-node-btn:before {

--- a/src/views/portfolio/projects/ProjectDependencyGraph.vue
+++ b/src/views/portfolio/projects/ProjectDependencyGraph.vue
@@ -86,7 +86,7 @@ export default {
         let response = await this.axios.get(url);
         let data = response.data;
         if (data && data.directDependencies) {
-          treeNode.children = this.transformDependenciesToOrgTree(JSON.parse(data.directDependencies), false);
+          this.$set(treeNode, 'children', this.transformDependenciesToOrgTree(JSON.parse(data.directDependencies), true) )
         }
       }
       return dependencyFunc();

--- a/src/views/portfolio/projects/ProjectDependencyGraph.vue
+++ b/src/views/portfolio/projects/ProjectDependencyGraph.vue
@@ -1,5 +1,5 @@
 <template>
-  <div style="max-height: 58.465vh; overflow: auto">
+  <div style="overflow-x: hidden; overflow-y: hidden; cursor: grab" @mousedown="mouseDownHandler">
     <vue2-org-tree
       :data="data"
       :horizontal="true"
@@ -17,6 +17,8 @@
 <script>
 import Vue2OrgTree from 'vue2-org-tree'
 import permissionsMixin from "../../../mixins/permissionsMixin";
+
+let pos = { top: 0, left: 0, x: 0, y: 0};
 
 export default {
   mixins: [permissionsMixin],
@@ -58,6 +60,52 @@ export default {
     }
   },
   methods: {
+    mouseDownHandler: function (event) {
+      if (event.button === 0 && !event.target.classList.contains("clickable-node") && !event.target.classList.contains("org-tree-node-btn")){
+        this.$el.style.cursor = "grabbing";
+        this.$el.style.userSelect = 'none';
+        pos = {
+          left: this.$el.scrollLeft,
+          top: document.documentElement.scrollTop,
+          x: event.clientX,
+          y: event.clientY,
+        }
+        document.addEventListener('mousemove', this.mouseMoveHandler)
+        document.addEventListener("mouseup", this.mouseUpHandler)
+      } else if (event.button === 1) {
+        this.$el.style.cursor = "default";
+        this.$el.style.userSelect = 'none';
+        pos = {
+          left: this.$el.scrollLeft,
+          top: document.documentElement.scrollTop,
+          x: event.clientX,
+          y: event.clientY,
+        }
+        console.log("pos: %o", pos)
+        document.addEventListener('mousemove', this.mouseMoveHandlerMiddleMouseButton)
+        document.addEventListener("mouseup", this.mouseUpHandler)
+      }
+    },
+    mouseMoveHandler: function (event) {
+      const dx = event.clientX - pos.x
+      const dy = event.clientY - pos.y
+
+      document.documentElement.scrollTop = pos.top - dy
+      this.$el.scrollLeft = pos.left - dx
+    },
+    mouseMoveHandlerMiddleMouseButton: function (event) {
+      const dx = event.clientX - pos.x
+
+      this.$el.scrollLeft = pos.left + dx
+    },
+    mouseUpHandler: function (event) {
+      document.removeEventListener('mousemove', this.mouseMoveHandler);
+      document.removeEventListener('mousemove', this.mouseMoveHandlerMiddleMouseButton)
+      document.removeEventListener('mouseup', this.mouseUpHandler);
+
+      this.$el.style.cursor = 'grab';
+      this.$el.style.removeProperty('user-select');
+    },
     transformDependenciesToOrgTree: function(dependencies, getChildren, treeNode) {
       let children = null;
       if (dependencies && dependencies.length > 0) {
@@ -137,19 +185,21 @@ export default {
     renderContent: function(h, data) {
       return data.label
     },
-    onExpand: function(e, data) {
+    onExpand: async function (e, data) {
       if ('expand' in data) {
         data.expand = !data.expand
         if (!data.expand && data.children) {
           this.collapse(data.children)
         }
       } else {
-        if (!data.fetchedChildren){
-          for (const child of data.children){
-            this.getChildrenFromDependency(child, child)
+        if (!data.fetchedChildren) {
+          e.target.style.cursor = "wait"
+          for (const child of data.children) {
+            await this.getChildrenFromDependency(child, child)
           }
           data.fetchedChildren = true
         }
+        e.target.style.cursor = "pointer"
         this.$set(data, 'expand', true)
       }
     },
@@ -201,6 +251,8 @@ export default {
   }
   .org-tree-node-label .org-tree-node-label-inner {
     border: 1px solid #20a8d8;
+    padding: 1px 2.5px;
+    font-size: 0.675rem;
   }
   .org-tree-node-label:hover {
     cursor: pointer;
@@ -209,6 +261,7 @@ export default {
     background-color: #105770;
     color: #ffffff;
     border: none;
+    pointer-events: initial;
   }
   .org-tree-node-btn:hover {
     background-color: #20a8d8;
@@ -224,5 +277,61 @@ export default {
   }
   .horizontal.collapsable .org-tree-node.collapsed .org-tree-node-label:after {
     border-bottom: 1px solid #20a8d8;
+  }
+  // Fixes white line instead of blue line to only-child nodes
+  .horizontal .org-tree-node:only-child:before {
+    border-bottom-color: #20a8d8;
+  }
+  // Horizontal line to a node
+  .horizontal .org-tree-node:after, .horizontal .org-tree-node:before, .horizontal .org-tree-node.is-leaf:before, .org-tree-node.is-leaf:after {
+    width: 10px;
+    height: 50%;
+  }
+  // Horizontal line from a node
+  .horizontal .org-tree-node-children {
+    padding-left: 10px;
+  }
+  .horizontal.collapsable .org-tree-node.collapsed .org-tree-node-label:after, .horizontal .org-tree-node-children:before {
+    width: 10px;
+  }
+  // Margin between nodes
+  .horizontal .org-tree-node, .horizontal .org-tree-node.collapsed, .horizontal .org-tree-node.is-leaf {
+    padding: 0;
+  }
+  .horizontal .org-tree-node-label {
+    padding: 5px 0px 5px 10px
+  }
+  // Button size and position
+  .horizontal .org-tree-node-btn {
+    width: 14px;
+    height: 14px;
+    margin: -7px 0px 0px 2.85px;
+  }
+  // Inner button vertical line
+  .org-tree-node-btn:before {
+    left: 3px;
+    right: 3px;
+    top: 50%;
+  }
+  // Inner button horizontal line
+  .org-tree-node-btn:after {
+    top: 3px;
+    bottom: 3px;
+    left: 50%;
+  }
+  // Fix wrong pointer
+  .org-tree-node-label:hover {
+    cursor: default;
+  }
+  .org-tree-node-label .org-tree-node-label-inner {
+    cursor: pointer;
+  }
+  // Enable dragging nodes without scrolling by dragging
+  .org-tree-node-label-inner {
+    pointer-events: initial;
+  }
+  // Enable scrolling by dragging in empty space between nodes
+  .org-tree-node-label {
+    pointer-events: none;
   }
 </style>


### PR DESCRIPTION
### Description
**Current Behavior:**
A project's dependency graph can only be expanded up to its third level, which makes it hardly usable and the size of the elements inside the graph makes it unnecessarily big and harder to read/navigate.
Also, the data for every node is requested at the same time, which can lead to huge traffic in projects with many dependencies.

**Proposed Behavior:**
The dependency graph of a project can be fully expanded to search for every dependency and only the necessary data for the expanding node is lazily loaded to reduce the amount of traffic.  Every path in the graph is also checked for circular references and prevents displaying them. 
The size of the buttons, the nodes, the font and other elements is reduced to improve the readability for bigger dependency graphs.
<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details

![image](https://user-images.githubusercontent.com/113189967/202122495-896fa74e-fead-49a4-bf20-5b7dcbd0ea0e.png)

A PR will follow, that attaches a `Show in dependency graph` button to a component in different views, which redirects a user to the project's dependency graph and then expands the path to every occurrence of the selected component. 

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/github-templates/CONTRIBUTING.md#pull-requests)
- [ ] ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
