### PR TITLE
Click on node to open component view

### DIFF
--- a/src/views/portfolio/projects/ProjectDependencyGraph.vue
+++ b/src/views/portfolio/projects/ProjectDependencyGraph.vue
@@ -206,10 +206,10 @@ export default {
     onNodeClick: function(e, data) {
       //console.log('onNodeClick: %o', data)
       this.$set(data, 'selectedKey', !data.selectedKey)
-      if (data.type === 'component') {
-        this.$router.replace({ path: "/components/" + data.uuid });
-      } else if (data.type === 'service') {
-        this.$router.replace({ path: "/services/" + data.uuid });
+      if (data.objectType === 'COMPONENT') {
+        this.$router.push({ path: "/components/" + data.uuid });
+      } else if (data.objectType === 'SERVICE') {
+        this.$router.push({ path: "/services/" + data.uuid });
       }
     },
     collapse: function(list) {


### PR DESCRIPTION
### Description
Currently, the nodes in the dependency graph are clickable, but clicking them does nothing.
With this PR, clicking on a node will either lead you to the component (`/api/v1/components/<componentUUID>`) or service (`/api/v1/services/<serviceUUID>`) view of the node.

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

### Addressed Issue

New Issue will be created, after this PR is merged.

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/github-templates/CONTRIBUTING.md#pull-requests)
~- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
