### PR TITLE
Display version status in `Audit Vulnerabilities` and `Exploit Predictions` tab

### DIFF
--- a/src/views/portfolio/projects/ProjectEpss.vue
+++ b/src/views/portfolio/projects/ProjectEpss.vue
@@ -29,6 +29,7 @@ import i18n from "../../../i18n";
 import permissionsMixin from "../../../mixins/permissionsMixin";
 import BootstrapToggle from 'vue-bootstrap-toggle';
 import ChartEpssVsCvss from "../../dashboard/ChartEpssVsCvss";
+import $ from "jquery";
 
 export default {
   props: {
@@ -62,7 +63,15 @@ export default {
           field: "component.version",
           sortable: true,
           formatter(value, row, index) {
-            return xssFilters.inHTMLData(common.valueWithDefault(value, ""));
+            if (Object.prototype.hasOwnProperty.call(row.component, "latestVersion")) {
+              if (row.component.latestVersion !== row.component.version) {
+                return '<span style="float:right" data-toggle="tooltip" data-placement="bottom" title="Risk: Outdated component. Current version is: '+ xssFilters.inHTMLData(row.component.latestVersion) + '"><i class="fa fa-exclamation-triangle status-warning" aria-hidden="true"></i></span> ' + xssFilters.inHTMLData(row.component.version);
+              } else {
+                return '<span style="float:right" data-toggle="tooltip" data-placement="bottom" title="Component version is the latest available from the configured repositories"><i class="fa fa-exclamation-triangle status-passed" aria-hidden="true"></i></span> ' + xssFilters.inHTMLData(row.component.version);
+              }
+            } else {
+              return xssFilters.inHTMLData(common.valueWithDefault(value, ""));
+            }
           }
         },
         {
@@ -133,7 +142,8 @@ export default {
           res.total = xhr.getResponseHeader("X-Total-Count");
           return res;
         },
-        url: this.apiUrl()
+        url: this.apiUrl(),
+        onPostBody: this.initializeTooltips,
       }
     };
   },
@@ -156,7 +166,10 @@ export default {
     tableLoaded: function(data) {
       this.$emit('total', data.total);
       this.$refs.chartEpssVsCvss.render(data);
-    }
+    },
+    initializeTooltips: function () {
+      $('[data-toggle="tooltip"]').tooltip();
+    },
   },
   watch:{
     showSuppressedFindings() {

--- a/src/views/portfolio/projects/ProjectFindings.vue
+++ b/src/views/portfolio/projects/ProjectFindings.vue
@@ -95,7 +95,15 @@
             field: "component.version",
             sortable: true,
             formatter(value, row, index) {
-              return xssFilters.inHTMLData(common.valueWithDefault(value, ""));
+              if (Object.prototype.hasOwnProperty.call(row.component, "latestVersion")) {
+                if (row.component.latestVersion !== row.component.version) {
+                  return '<span style="float:right" data-toggle="tooltip" data-placement="bottom" title="Risk: Outdated component. Current version is: '+ xssFilters.inHTMLData(row.component.latestVersion) + '"><i class="fa fa-exclamation-triangle status-warning" aria-hidden="true"></i></span> ' + xssFilters.inHTMLData(row.component.version);
+                } else {
+                  return '<span style="float:right" data-toggle="tooltip" data-placement="bottom" title="Component version is the latest available from the configured repositories"><i class="fa fa-exclamation-triangle status-passed" aria-hidden="true"></i></span> ' + xssFilters.inHTMLData(row.component.version);
+                }
+              } else {
+                return xssFilters.inHTMLData(common.valueWithDefault(value, ""));
+              }
             }
           },
           {


### PR DESCRIPTION
### Description

Information about the version status of a component is currently only displayed in the `Components` tab of a project.

Also adding this information to the `Audit Vulnerabilities` and the `Exploit Predictions` tab of a project improves the usability of those two tabs, because it is no longer needed to switch tabs to check for version status information.

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

### Addressed Issue

New Issue in the frontend will be created after this PR is merged.

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details

Enhanced the `/finding/project/<projectUUID>` endpoint in the [Backend PR](https://github.com/rbt-mm/dependency-track/pull/16) to correctly display the information in the tabs.

![image](https://user-images.githubusercontent.com/113189967/206444203-2e74d284-5fc9-4941-a5a6-21a38c389192.png)

![image](https://user-images.githubusercontent.com/113189967/206444334-c144fcc7-96b9-4ff3-9f37-987b86959570.png)

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/github-templates/CONTRIBUTING.md#pull-requests)
~- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
