### PR TITLE
Implement deep and nested routing

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -747,7 +747,8 @@
     "http_status_code": "HTTP Status Code",
     "unsuccessful_action": "Could not perform the requested action",
     "http_request_error": "HTTP Request Error",
-    "server_error": "Server Error"
+    "server_error": "Server Error",
+    "forbidden": "Forbidden (403)"
   },
   "violation": {
     "info": "Inform",

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -2,7 +2,7 @@ import Vue from 'vue'
 import Router from 'vue-router'
 import i18n from '../i18n'
 import { getContextPath } from "../shared/utils"
-import { getToken }  from '../shared/permissions';
+import {decodeToken, getToken} from '../shared/permissions';
 import EventBus from '../shared/eventbus';
 
 // Containers
@@ -14,10 +14,52 @@ const ProjectList = () => import('@/views/portfolio/projects/ProjectList');
 const ComponentSearch = () => import('@/views/portfolio/components/ComponentSearch');
 const VulnerabilityList = () => import('@/views/portfolio/vulnerabilities/VulnerabilityList');
 const LicenseList = () => import('@/views/portfolio/licenses/LicenseList');
-const Administration = () => import('@/views/administration/Administration');
 const PolicyManagement = () => import('@/views/policy/PolicyManagement');
-
 const Project = () => import('@/views/portfolio/projects/Project');
+
+const Administration = () => import('@/views/administration/Administration');
+const General = () => import('@/views/administration/configuration/General')
+const BomFormats = () => import('@/views/administration/configuration/BomFormats')
+const Email = () => import('@/views/administration/configuration/Email')
+const Jira = () => import('@/views/administration/configuration/JiraConfig')
+const InternalComponents = () => import('@/views/administration/configuration/InternalComponents')
+const TaskScheduler = () => import('@/views/administration/configuration/TaskScheduler')
+const Search = () => import('@/views/administration/configuration/Search')
+
+const InternalAnalyzer = () => import('@/views/administration/analyzers/InternalAnalyzer')
+const OssIndexAnalyzer = () => import('@/views/administration/analyzers/OssIndexAnalyzer')
+const VulnDbAnalyzer = () => import('@/views/administration/analyzers/VulnDbAnalyzer')
+const SnykAnalyzer = () => import('@/views/administration/analyzers/SnykAnalyzer')
+
+const VulnSourceNvd = () => import('@/views/administration/vuln-sources/VulnSourceNvd')
+const VulnSourceGitHubAdvisories = () => import('@/views/administration/vuln-sources/VulnSourceGitHubAdvisories')
+const VulnSourceOSVAdvisories = () => import('@/views/administration/vuln-sources/VulnSourceOSVAdvisories')
+
+const Cargo = () => import('@/views/administration/repositories/Cargo')
+const Composer = () => import('@/views/administration/repositories/Composer')
+const Gem = () => import('@/views/administration/repositories/Gem')
+const GoModules = () => import('@/views/administration/repositories/GoModules')
+const Hex = () => import('@/views/administration/repositories/Hex')
+const Maven = () => import('@/views/administration/repositories/Maven')
+const Npm = () => import('@/views/administration/repositories/Npm')
+const Nuget = () => import('@/views/administration/repositories/Nuget')
+const Python = () => import('@/views/administration/repositories/Python')
+
+const Alerts = () => import('@/views/administration/notifications/Alerts')
+const Templates = () => import('@/views/administration/notifications/Templates')
+
+const FortifySsc = () => import('@/views/administration/integrations/FortifySsc')
+const DefectDojo = () => import('@/views/administration/integrations/DefectDojo')
+const KennaSecurity = () => import('@/views/administration/integrations/KennaSecurity')
+
+const LdapUsers = () => import('@/views/administration/accessmanagement/LdapUsers')
+const ManagedUsers = () => import('@/views/administration/accessmanagement/ManagedUsers')
+const OidcUsers = () => import('@/views/administration/accessmanagement/OidcUsers')
+const OidcGroups = () => import('@/views/administration/accessmanagement/OidcGroups')
+const Teams = () => import('@/views/administration/accessmanagement/Teams')
+const Permissions = () => import('@/views/administration/accessmanagement/Permissions')
+const PortfolioAccessControl = () => import('@/views/administration/accessmanagement/PortfolioAccessControl')
+
 const Component = () => import('@/views/portfolio/projects/Component');
 const Service = () => import('@/views/portfolio/projects/Service');
 const Vulnerability = () => import('@/views/portfolio/vulnerabilities/Vulnerability');
@@ -55,17 +97,20 @@ function configRoutes() {
           meta: {
             title: i18n.t('message.projects'),
             i18n: 'message.projects',
-            sectionPath: '/projects'
+            sectionPath: '/projects',
+            permission: 'VIEW_PORTFOLIO'
           }
         },
         {
           path: 'projects/:uuid',
           name: 'Project',
+          alias: ['projects/:uuid/overview', 'projects/:uuid/components', 'projects/:uuid/services', 'projects/:uuid/dependencyGraph', 'projects/:uuid/findings', 'projects/:uuid/epss', 'projects/:uuid/policyViolations'],
           props: (route) => ( { uuid: route.params.uuid } ),
           component: Project,
           meta: {
             i18n: 'message.projects',
-            sectionPath: '/projects'
+            sectionPath: '/projects',
+            permission: 'VIEW_PORTFOLIO'
           }
         },
         {
@@ -78,7 +123,8 @@ function configRoutes() {
           component: Project,
           meta: {
             i18n: 'message.projects',
-            sectionPath: '/projects'
+            sectionPath: '/projects',
+            permission: 'VIEW_PORTFOLIO'
           }
         },
         {
@@ -88,17 +134,20 @@ function configRoutes() {
           meta: {
             title: i18n.t('message.component_search'),
             i18n: 'message.component_search',
-            sectionPath: '/components'
+            sectionPath: '/components',
+            permission: 'VIEW_PORTFOLIO'
           }
         },
         {
           path: '/components/:uuid',
           name: 'Component',
+          alias: ['/components/:uuid/overview', '/components/:uuid/vulnerabilities'],
           props: (route) => ( { uuid: route.params.uuid } ),
           component: Component,
           meta: {
             i18n: 'message.projects',
-            sectionPath: '/projects'
+            sectionPath: '/projects',
+            permission: 'VIEW_PORTFOLIO'
           }
         },
         {
@@ -108,7 +157,8 @@ function configRoutes() {
           component: Service,
           meta: {
             i18n: 'message.projects',
-            sectionPath: '/projects'
+            sectionPath: '/projects',
+            permission: 'VIEW_PORTFOLIO'
           }
         },
         {
@@ -118,12 +168,14 @@ function configRoutes() {
           meta: {
             title: i18n.t('message.vulnerabilities'),
             i18n: 'message.vulnerabilities',
-            sectionPath: '/vulnerabilities'
+            sectionPath: '/vulnerabilities',
+            permission: 'VIEW_PORTFOLIO'
           }
         },
         {
           path: 'vulnerabilities/:source/:vulnId',
           name: 'Vulnerability',
+          alias: ['vulnerabilities/:source/:vulnId/overview', 'vulnerabilities/:source/:vulnId/affectedProjects'],
           props: (route) => ( {
             source: route.params.source,
             vulnId: route.params.vulnId
@@ -131,7 +183,8 @@ function configRoutes() {
           component: Vulnerability,
           meta: {
             i18n: 'message.vulnerabilities',
-            sectionPath: '/vulnerabilities'
+            sectionPath: '/vulnerabilities',
+            permission: 'VIEW_PORTFOLIO'
           }
         },
         {
@@ -141,38 +194,403 @@ function configRoutes() {
           meta: {
             title: i18n.t('message.licenses'),
             i18n: 'message.licenses',
-            sectionPath: '/licenses'
+            sectionPath: '/licenses',
+            permission: 'VIEW_PORTFOLIO'
           }
         },
         {
           path: 'licenses/:licenseId',
           name: 'License',
+          alias: ['licenses/:licenseId/overview', 'licenses/:licenseId/licenseText', 'licenses/:licenseId/template', 'licenses/:licenseId/header'],
           props: (route) => ( { licenseId: route.params.licenseId } ),
           component: License,
           meta: {
             i18n: 'message.licenses',
-            sectionPath: '/licenses'
+            sectionPath: '/licenses',
+            permission: 'VIEW_PORTFOLIO'
           }
         },
         {
           path: 'policy',
           name: 'Policy Management',
+          alias: ['policy/policies', 'policy/licenseGroups'],
           component: PolicyManagement,
           meta: {
             title: i18n.t('message.policy_management'),
             i18n: 'message.policy_management',
-            sectionPath: '/policy'
+            sectionPath: '/policy',
+            permission: 'POLICY_MANAGEMENT'
           }
         },
         {
           path: 'admin',
-          name: 'Administration',
           component: Administration,
           meta: {
             title: i18n.t('message.administration'),
             i18n: 'message.administration',
-            sectionPath: '/admin'
-          }
+            sectionPath: '/admin',
+            permission: 'SYSTEM_CONFIGURATION'
+          },
+          children: [
+            {
+              path: '',
+              name: 'Administration',
+              alias: ['configuration', 'configuration/general'],
+              component: General,
+              meta: {
+                title: i18n.t('message.administration'),
+                i18n: 'message.administration',
+                sectionPath: '/admin',
+                permission: 'SYSTEM_CONFIGURATION'
+              },
+            },
+            {
+              path: 'configuration/bomFormats',
+              component: BomFormats,
+              meta: {
+                title: i18n.t('message.administration'),
+                i18n: 'message.administration',
+                sectionPath: '/admin',
+                permission: 'SYSTEM_CONFIGURATION'
+              },
+            },
+            {
+              path: 'configuration/email',
+              component: Email,
+              meta: {
+                title: i18n.t('message.administration'),
+                i18n: 'message.administration',
+                sectionPath: '/admin',
+                permission: 'SYSTEM_CONFIGURATION'
+              },
+            },
+            {
+              path: 'configuration/jira',
+              component: Jira,
+              meta: {
+                title: i18n.t('message.administration'),
+                i18n: 'message.administration',
+                sectionPath: '/admin',
+                permission: 'SYSTEM_CONFIGURATION'
+              },
+            },
+            {
+              path: 'configuration/internalComponents',
+              component: InternalComponents,
+              meta: {
+                title: i18n.t('message.administration'),
+                i18n: 'message.administration',
+                sectionPath: '/admin',
+                permission: 'SYSTEM_CONFIGURATION'
+              },
+            },
+            {
+              path: 'configuration/taskScheduler',
+              component: TaskScheduler,
+              meta: {
+                title: i18n.t('message.administration'),
+                i18n: 'message.administration',
+                sectionPath: '/admin',
+                permission: 'SYSTEM_CONFIGURATION'
+              },
+            },
+            {
+              path: 'configuration/search',
+              component: Search,
+              meta: {
+                title: i18n.t('message.administration'),
+                i18n: 'message.administration',
+                sectionPath: '/admin',
+                permission: 'SYSTEM_CONFIGURATION'
+              },
+            },
+            {
+              path: 'analyzers/internal',
+              alias: ['analyzers'],
+              component: InternalAnalyzer,
+              meta: {
+                title: i18n.t('message.administration'),
+                i18n: 'message.administration',
+                sectionPath: '/admin',
+                permission: 'SYSTEM_CONFIGURATION'
+              },
+            },
+            {
+              path: 'analyzers/oss',
+              component: OssIndexAnalyzer,
+              meta: {
+                title: i18n.t('message.administration'),
+                i18n: 'message.administration',
+                sectionPath: '/admin',
+                permission: 'SYSTEM_CONFIGURATION'
+              },
+            },
+            {
+              path: 'analyzers/vulnDB',
+              component: VulnDbAnalyzer,
+              meta: {
+                title: i18n.t('message.administration'),
+                i18n: 'message.administration',
+                sectionPath: '/admin',
+                permission: 'SYSTEM_CONFIGURATION'
+              },
+            },
+            {
+              path: 'analyzers/snyk',
+              component: SnykAnalyzer,
+              meta: {
+                title: i18n.t('message.administration'),
+                i18n: 'message.administration',
+                sectionPath: '/admin',
+                permission: 'SYSTEM_CONFIGURATION'
+              },
+            },
+            {
+              path: 'vulnerabilitySources/nvd',
+              alias: ['vulnerabilitySources'],
+              component: VulnSourceNvd,
+              meta: {
+                title: i18n.t('message.administration'),
+                i18n: 'message.administration',
+                sectionPath: '/admin',
+                permission: 'SYSTEM_CONFIGURATION'
+              },
+            },
+            {
+              path: 'vulnerabilitySources/github',
+              component: VulnSourceGitHubAdvisories,
+              meta: {
+                title: i18n.t('message.administration'),
+                i18n: 'message.administration',
+                sectionPath: '/admin',
+                permission: 'SYSTEM_CONFIGURATION'
+              },
+            },
+            {
+              path: 'vulnerabilitySources/osv',
+              component: VulnSourceOSVAdvisories,
+              meta: {
+                title: i18n.t('message.administration'),
+                i18n: 'message.administration',
+                sectionPath: '/admin',
+                permission: 'SYSTEM_CONFIGURATION'
+              },
+            },
+            {
+              path: 'repositories/cargo',
+              alias: ['repositories'],
+              component: Cargo,
+              meta: {
+                title: i18n.t('message.administration'),
+                i18n: 'message.administration',
+                sectionPath: '/admin',
+                permission: 'SYSTEM_CONFIGURATION'
+              },
+            },
+            {
+              path: 'repositories/composer',
+              component: Composer,
+              meta: {
+                title: i18n.t('message.administration'),
+                i18n: 'message.administration',
+                sectionPath: '/admin',
+                permission: 'SYSTEM_CONFIGURATION'
+              },
+            },
+            {
+              path: 'repositories/gem',
+              component: Gem,
+              meta: {
+                title: i18n.t('message.administration'),
+                i18n: 'message.administration',
+                sectionPath: '/admin',
+                permission: 'SYSTEM_CONFIGURATION'
+              },
+            },
+            {
+              path: 'repositories/goModules',
+              component: GoModules,
+              meta: {
+                title: i18n.t('message.administration'),
+                i18n: 'message.administration',
+                sectionPath: '/admin',
+                permission: 'SYSTEM_CONFIGURATION'
+              },
+            },
+            {
+              path: 'repositories/hex',
+              component: Hex,
+              meta: {
+                title: i18n.t('message.administration'),
+                i18n: 'message.administration',
+                sectionPath: '/admin',
+                permission: 'SYSTEM_CONFIGURATION'
+              },
+            },
+            {
+              path: 'repositories/maven',
+              component: Maven,
+              meta: {
+                title: i18n.t('message.administration'),
+                i18n: 'message.administration',
+                sectionPath: '/admin',
+                permission: 'SYSTEM_CONFIGURATION'
+              },
+            },
+            {
+              path: 'repositories/npm',
+              component: Npm,
+              meta: {
+                title: i18n.t('message.administration'),
+                i18n: 'message.administration',
+                sectionPath: '/admin',
+                permission: 'SYSTEM_CONFIGURATION'
+              },
+            },
+            {
+              path: 'repositories/nuget',
+              component: Nuget,
+              meta: {
+                title: i18n.t('message.administration'),
+                i18n: 'message.administration',
+                sectionPath: '/admin',
+                permission: 'SYSTEM_CONFIGURATION'
+              },
+            },
+            {
+              path: 'repositories/python',
+              component: Python,
+              meta: {
+                title: i18n.t('message.administration'),
+                i18n: 'message.administration',
+                sectionPath: '/admin',
+                permission: 'SYSTEM_CONFIGURATION'
+              },
+            },
+            {
+              path: 'notifications/alerts',
+              alias: ['notifications'],
+              component: Alerts,
+              meta: {
+                title: i18n.t('message.administration'),
+                i18n: 'message.administration',
+                sectionPath: '/admin',
+                permission: 'SYSTEM_CONFIGURATION'
+              },
+            },
+            {
+              path: 'notifications/templates',
+              component: Templates,
+              meta: {
+                title: i18n.t('message.administration'),
+                i18n: 'message.administration',
+                sectionPath: '/admin',
+                permission: 'SYSTEM_CONFIGURATION'
+              },
+            },
+            {
+              path: 'integrations/fortifySSC',
+              alias: ['integrations'],
+              component: FortifySsc,
+              meta: {
+                title: i18n.t('message.administration'),
+                i18n: 'message.administration',
+                sectionPath: '/admin',
+                permission: 'SYSTEM_CONFIGURATION'
+              },
+            },
+            {
+              path: 'integrations/defectDojo',
+              component: DefectDojo,
+              meta: {
+                title: i18n.t('message.administration'),
+                i18n: 'message.administration',
+                sectionPath: '/admin',
+                permission: 'SYSTEM_CONFIGURATION'
+              },
+            },
+            {
+              path: 'integrations/kennaSecurity',
+              component: KennaSecurity,
+              meta: {
+                title: i18n.t('message.administration'),
+                i18n: 'message.administration',
+                sectionPath: '/admin',
+                permission: 'SYSTEM_CONFIGURATION'
+              },
+            },
+            {
+              path: 'accessManagement/ldapUsers',
+              alias: ['accessManagement'],
+              component: LdapUsers,
+              meta: {
+                title: i18n.t('message.administration'),
+                i18n: 'message.administration',
+                sectionPath: '/admin',
+                permission: 'ACCESS_MANAGEMENT'
+              },
+            },
+            {
+              path: 'accessManagement/managedUsers',
+              component: ManagedUsers,
+              meta: {
+                title: i18n.t('message.administration'),
+                i18n: 'message.administration',
+                sectionPath: '/admin',
+                permission: 'ACCESS_MANAGEMENT'
+              },
+            },
+            {
+              path: 'accessManagement/oidcUsers',
+              component: OidcUsers,
+              meta: {
+                title: i18n.t('message.administration'),
+                i18n: 'message.administration',
+                sectionPath: '/admin',
+                permission: 'ACCESS_MANAGEMENT'
+              },
+            },
+            {
+              path: 'accessManagement/oidcGroups',
+              component: OidcGroups,
+              meta: {
+                title: i18n.t('message.administration'),
+                i18n: 'message.administration',
+                sectionPath: '/admin',
+                permission: 'ACCESS_MANAGEMENT'
+              },
+            },
+            {
+              path: 'accessManagement/teams',
+              component: Teams,
+              meta: {
+                title: i18n.t('message.administration'),
+                i18n: 'message.administration',
+                sectionPath: '/admin',
+                permission: 'ACCESS_MANAGEMENT'
+              },
+            },
+            {
+              path: 'accessManagement/permissions',
+              component: Permissions,
+              meta: {
+                title: i18n.t('message.administration'),
+                i18n: 'message.administration',
+                sectionPath: '/admin',
+                permission: 'ACCESS_MANAGEMENT'
+              },
+            },
+            {
+              path: 'accessManagement/portfolioAccessControl',
+              component: PortfolioAccessControl,
+              meta: {
+                title: i18n.t('message.administration'),
+                i18n: 'message.administration',
+                sectionPath: '/admin',
+                permission: 'ACCESS_MANAGEMENT'
+              },
+            }
+          ]
         },
         // The following route redirects URLs from legacy Dependency-Track UI to new URL format.
         {
@@ -268,31 +686,36 @@ const router = new Router({
 
 router.beforeEach((to, from, next) => {
   const jwt = getToken();
-  const publicRoutes = ['Login', '404', 'PasswordForceChange'];
-  if (!publicRoutes.includes(to.name)) {
-    const redirectTo = to.fullPath;
-    if (jwt) {
-      // let backend verify the token
-      router.app.axios.get(`${router.app.$api.BASE_URL}/${router.app.$api.URL_USER_SELF}`, {
-        headers: { 'Authorization': `Bearer ${jwt}` }
-      }).then((result) => {
-        Vue.prototype.$currentUser = result.data
-        // allowed to proceed
-        next();
-      }).catch(() => {
-        // token is stale
-        // notify app about this
-        EventBus.$emit('authenticated', null);
-        // redirect to login page
+  if (!to.meta.permission || to.meta.permission && jwt && decodeToken(jwt).permissions.includes(to.meta.permission)){
+    const publicRoutes = ['Login', '404', 'PasswordForceChange'];
+    if (!publicRoutes.includes(to.name)) {
+      const redirectTo = to.fullPath;
+      if (jwt) {
+        // let backend verify the token
+        router.app.axios.get(`${router.app.$api.BASE_URL}/${router.app.$api.URL_USER_SELF}`, {
+          headers: { 'Authorization': `Bearer ${jwt}` }
+        }).then((result) => {
+          Vue.prototype.$currentUser = result.data
+          // allowed to proceed
+          next();
+        }).catch(() => {
+          // token is stale
+          // notify app about this
+          EventBus.$emit('authenticated', null);
+          // redirect to login page
+          next({ name: 'Login', query: { redirect: redirectTo }, replace: true });
+        });
+      } else {
+        // no token at all, redirect to login page
         next({ name: 'Login', query: { redirect: redirectTo }, replace: true });
-      });
+      }
     } else {
-      // no token at all, redirect to login page
-      next({ name: 'Login', query: { redirect: redirectTo }, replace: true });
+      // allowed to proceed
+      next();
     }
   } else {
-    // allowed to proceed
-    next();
+    Vue.prototype.$toastr.e(i18n.t('condition.forbidden'));
+    next({name: "Dashboard", replace: true})
   }
 });
 

--- a/src/views/administration/AdminMenu.vue
+++ b/src/views/administration/AdminMenu.vue
@@ -5,10 +5,10 @@
       <div slot="header" v-if="isPermitted(section.permission)" v-b-toggle="section.id" style="cursor:pointer;">
         <i class="fa fa-align-justify"></i><strong>&nbsp;&nbsp;{{ section.name }}</strong>
       </div>
-      <b-collapse v-if="isPermitted(section.permission)" :id="section.id" visible accordion="admin-accordion" role="tabpanel">
+      <b-collapse ref="accordion" v-if="isPermitted(section.permission)" :id="section.id" accordion="admin-accordion" role="tabpanel">
         <div class="list-group" id="list-tab" role="tablist">
-          <a v-for="item in section.children" class="list-group-item list-group-item-action" data-toggle="list" role="tab"
-             :href="item.href" @click="emitEvent(item)">{{ item.name }}</a>
+          <router-link :ref="item.id" v-for="item in section.children" class="list-group-item list-group-item-action" data-toggle="list" role="tab"
+             :to="'/admin/' + item.route" @click="emitEvent(item)">{{ item.name }}</router-link>
         </div>
       </b-collapse>
     </b-card>
@@ -31,6 +31,45 @@
         EventBus.$emit('admin:plugin', plugin);
       }
     },
+    mounted() {
+      let path = this.$route.fullPath.toLowerCase()
+      if (path.includes('/analyzers')) {
+        this.$root.$emit('bv::toggle::collapse', 'analyzersMenu')
+      } else if (path.includes('/vulnerabilitysources')) {
+        this.$root.$emit('bv::toggle::collapse', 'vulnSourceMenu')
+      } else if (path.includes('/repositories')) {
+        this.$root.$emit('bv::toggle::collapse', 'repositoriesMenu')
+      } else if (path.includes('/notifications')) {
+        this.$root.$emit('bv::toggle::collapse', 'notificationsMenu')
+      } else if (path.includes('/integrations')) {
+        this.$root.$emit('bv::toggle::collapse', 'integrationsMenu')
+      } else if (path.includes('/accessmanagement')) {
+        this.$root.$emit('bv::toggle::collapse', 'accessmanagementMenu')
+      } else {
+        this.$root.$emit('bv::toggle::collapse', 'configurationMenu')
+      }
+    },
+    watch: {
+      $route (to) {
+        this.$refs.accordion.forEach(o => o.show = false)
+        let path = to.fullPath.toLowerCase()
+        if (path.includes('/analyzers')) {
+          this.$root.$emit('bv::toggle::collapse', 'analyzersMenu')
+        } else if (path.includes('/vulnerabilitysources')) {
+          this.$root.$emit('bv::toggle::collapse', 'vulnSourceMenu')
+        } else if (path.includes('/repositories')) {
+          this.$root.$emit('bv::toggle::collapse', 'repositoriesMenu')
+        } else if (path.includes('/notifications')) {
+          this.$root.$emit('bv::toggle::collapse', 'notificationsMenu')
+        } else if (path.includes('/integrations')) {
+          this.$root.$emit('bv::toggle::collapse', 'integrationsMenu')
+        } else if (path.includes('/accessmanagement')) {
+          this.$root.$emit('bv::toggle::collapse', 'accessmanagementMenu')
+        } else {
+          this.$root.$emit('bv::toggle::collapse', 'configurationMenu')
+        }
+      }
+    },
     data() {
       return {
         menu: [
@@ -42,37 +81,37 @@
               {
                 component: 'General',
                 name: this.$t('admin.general'),
-                href: "#generalConfigTab"
+                route: "configuration/general"
               },
               {
                 component: 'BomFormats',
                 name: this.$t('admin.bom_formats'),
-                href: "#bomFormatsTab"
+                route: "configuration/bomFormats"
               },
               {
                 component: 'Email',
                 name: this.$t('admin.email'),
-                href: "#emailTab"
+                route: "configuration/email"
               },
               {
                 component: 'Jira',
                 name: this.$t('admin.jira'),
-                href: "#jiraTab"
+                route: "configuration/jira"
               },
               {
                 component: 'InternalComponents',
                 name: this.$t('admin.internal_components'),
-                href: "#internalComponentsTab"
+                route: "configuration/internalComponents"
               },
               {
                 component: 'TaskScheduler',
                 name: this.$t('admin.task_scheduler'),
-                href: "#taskSchedulerTab"
+                route: "configuration/taskScheduler"
               },
               {
                 component: 'Search',
                 name: this.$t('message.search'),
-                href: "#searchTab"
+                route: "configuration/search"
               }
             ]
           },
@@ -84,22 +123,22 @@
               {
                 component: "InternalAnalyzer",
                 name: this.$t('admin.internal_analyzer'),
-                href: "#scannerInternalTab"
+                route: "analyzers/internal"
               },
               {
                 component: "OssIndexAnalyzer",
                 name: this.$t('admin.oss_index'),
-                href: "#scannerOssIndexTab"
+                route: "analyzers/oss"
               },
               {
                 component: "VulnDbAnalyzer",
                 name: this.$t('admin.vulndb'),
-                href: "#scannerVulnDbTab"
+                route: "analyzers/vulnDB"
               },
               {
                 component: "SnykAnalyzer",
                 name: this.$t('admin.snyk'),
-                href: "#scannerSnykTab"
+                route: "analyzers/snyk"
               }
             ]
           },
@@ -111,17 +150,17 @@
               {
                 component: "VulnSourceNvd",
                 name: this.$t('admin.national_vulnerability_database'),
-                href: "#vulnsourceNvdTab"
+                route: "vulnerabilitySources/nvd"
               },
               {
                 component: "VulnSourceGitHubAdvisories",
                 name: this.$t('admin.github_advisories'),
-                href: "#vulnsourceGitHubAdvisoriesTab"
+                route: "vulnerabilitySources/github"
               },
               {
                 component: "VulnSourceOSVAdvisories",
                 name: this.$t('admin.osv_advisories'),
-                href: "#vulnsourceOSVAdvisoriesTab"
+                route: "vulnerabilitySources/osv"
               }
             ]
           },
@@ -133,47 +172,47 @@
               {
                 component: "Cargo",
                 name: this.$t('admin.cargo'),
-                href: "#repositoryCargoTab"
+                route: "repositories/cargo"
               },
               {
                 component: "Composer",
                 name: this.$t('admin.composer'),
-                href: "#repositoryComposerTab"
+                route: "repositories/composer"
               },
               {
                 component: "Gem",
                 name: this.$t('admin.gem'),
-                href: "#repositoryGemTab"
+                route: "repositories/gem"
               },
               {
                 component: "GoModules",
                 name: this.$t('admin.go_modules'),
-                href: "#repositoryGoModulesTab"
+                route: "repositories/goModules"
               },
               {
                 component: "Hex",
                 name: this.$t('admin.hex'),
-                href: "#repositoryHexTab"
+                route: "repositories/hex"
               },
               {
                 component: "Maven",
                 name: this.$t('admin.maven'),
-                href: "#repositoryMavenTab"
+                route: "repositories/maven"
               },
               {
                 component: "Npm",
                 name: this.$t('admin.npm'),
-                href: "#repositoryNpmTab"
+                route: "repositories/npm"
               },
               {
                 component: "Nuget",
                 name: this.$t('admin.nuget'),
-                href: "#repositoryNugetTab"
+                route: "repositories/nuget"
               },
               {
                 component: "Python",
                 name: this.$t('admin.python'),
-                href: "#repositoryPythonTab"
+                route: "repositories/python"
               }
             ]
           },
@@ -185,12 +224,12 @@
               {
                 component: "Alerts",
                 name: this.$t('admin.alerts'),
-                href: "#notificationAlertTab"
+                route: "notifications/alerts"
               },
               {
                 component: "Templates",
                 name: this.$t('admin.templates'),
-                href: "#notificationTemplateTab"
+                route: "notifications/templates"
               }
             ]
           },
@@ -202,17 +241,17 @@
               {
                 component: "FortifySsc",
                 name: this.$t('admin.fortify_ssc'),
-                href: "#integrationsFortifySscTab"
+                route: "integrations/fortifySSC"
               },
               {
                 component: "DefectDojo",
                 name: this.$t('admin.defectdojo'),
-                href: "#integrationsDefectDojoTab"
+                route: "integrations/defectDojo"
               },
               {
                 component: "KennaSecurity",
                 name: this.$t('admin.kenna_security'),
-                href: "#integrationsKennaSecurityTab"
+                route: "integrations/kennaSecurity"
               }
             ]
           },
@@ -224,37 +263,37 @@
               {
                 component: "LdapUsers",
                 name: this.$t('admin.ldap_users'),
-                href: "#ldapUsersTab"
+                route: "accessManagement/ldapUsers"
               },
               {
                 component: "ManagedUsers",
                 name: this.$t('admin.managed_users'),
-                href: "#managedUsersTab"
+                route: "accessManagement/managedUsers"
               },
               {
                 component: "OidcUsers",
                 name: this.$t('admin.oidc_users'),
-                href: "#oidcUsersTab"
+                route: "accessManagement/oidcUsers"
               },
               {
                 component: "OidcGroups",
                 name: this.$t('admin.oidc_groups'),
-                href: "#oidcGroupsTab"
+                route: "accessManagement/oidcGroups"
               },
               {
                 component: "Teams",
                 name: this.$t('admin.teams'),
-                href: "#teamsTab"
+                route: "accessManagement/teams"
               },
               {
                 component: "Permissions",
                 name: this.$t('admin.permissions'),
-                href: "#permissionsTab"
+                route: "accessManagement/permissions"
               },
               {
                 component: "PortfolioAccessControl",
                 name: this.$t('admin.portfolio_access_control'),
-                href: "#portfolioAclTab"
+                route: "accessManagement/portfolioAccessControl"
               },
             ]
           }

--- a/src/views/administration/AdminMenu.vue
+++ b/src/views/administration/AdminMenu.vue
@@ -29,45 +29,20 @@
     methods: {
       emitEvent: function(plugin) {
         EventBus.$emit('admin:plugin', plugin);
+      },
+      getMenuFromRoute: function() {
+        let pattern = new RegExp("/admin\\/([^\\/]*)", "gi");
+        let tab = pattern.exec(this.$route.fullPath.toLowerCase());
+        return tab && tab[1] ? tab[1].toLowerCase() : 'configuration';
       }
     },
     mounted() {
-      let path = this.$route.fullPath.toLowerCase()
-      if (path.includes('/analyzers')) {
-        this.$root.$emit('bv::toggle::collapse', 'analyzersMenu')
-      } else if (path.includes('/vulnerabilitysources')) {
-        this.$root.$emit('bv::toggle::collapse', 'vulnSourceMenu')
-      } else if (path.includes('/repositories')) {
-        this.$root.$emit('bv::toggle::collapse', 'repositoriesMenu')
-      } else if (path.includes('/notifications')) {
-        this.$root.$emit('bv::toggle::collapse', 'notificationsMenu')
-      } else if (path.includes('/integrations')) {
-        this.$root.$emit('bv::toggle::collapse', 'integrationsMenu')
-      } else if (path.includes('/accessmanagement')) {
-        this.$root.$emit('bv::toggle::collapse', 'accessmanagementMenu')
-      } else {
-        this.$root.$emit('bv::toggle::collapse', 'configurationMenu')
-      }
+      this.$root.$emit('bv::toggle::collapse', this.getMenuFromRoute())
     },
     watch: {
-      $route (to) {
-        this.$refs.accordion.forEach(o => o.show = false)
-        let path = to.fullPath.toLowerCase()
-        if (path.includes('/analyzers')) {
-          this.$root.$emit('bv::toggle::collapse', 'analyzersMenu')
-        } else if (path.includes('/vulnerabilitysources')) {
-          this.$root.$emit('bv::toggle::collapse', 'vulnSourceMenu')
-        } else if (path.includes('/repositories')) {
-          this.$root.$emit('bv::toggle::collapse', 'repositoriesMenu')
-        } else if (path.includes('/notifications')) {
-          this.$root.$emit('bv::toggle::collapse', 'notificationsMenu')
-        } else if (path.includes('/integrations')) {
-          this.$root.$emit('bv::toggle::collapse', 'integrationsMenu')
-        } else if (path.includes('/accessmanagement')) {
-          this.$root.$emit('bv::toggle::collapse', 'accessmanagementMenu')
-        } else {
-          this.$root.$emit('bv::toggle::collapse', 'configurationMenu')
-        }
+      $route () {
+        this.$refs.accordion.forEach(menu => menu.show = false);
+        this.$root.$emit('bv::toggle::collapse', this.getMenuFromRoute());
       }
     },
     data() {
@@ -75,7 +50,7 @@
         menu: [
           {
             name: this.$t('admin.configuration'),
-            id: "configurationMenu",
+            id: "configuration",
             permission: SYSTEM_CONFIGURATION,
             children: [
               {
@@ -117,7 +92,7 @@
           },
           {
             name: this.$t('admin.analyzers'),
-            id: "analyzersMenu",
+            id: "analyzers",
             permission: SYSTEM_CONFIGURATION,
             children: [
               {
@@ -144,7 +119,7 @@
           },
           {
             name: this.$t('admin.vuln_sources'),
-            id: "vulnSourceMenu",
+            id: "vulnerabilitysources",
             permission: SYSTEM_CONFIGURATION,
             children: [
               {
@@ -166,7 +141,7 @@
           },
           {
             name: this.$t('admin.repositories'),
-            id: "repositoriesMenu",
+            id: "repositories",
             permission: SYSTEM_CONFIGURATION,
             children: [
               {
@@ -218,7 +193,7 @@
           },
           {
             name: this.$t('admin.notifications'),
-            id: "notificationsMenu",
+            id: "notifications",
             permission: SYSTEM_CONFIGURATION,
             children: [
               {
@@ -235,7 +210,7 @@
           },
           {
             name: this.$t('admin.integrations'),
-            id: "integrationsMenu",
+            id: "integrations",
             permission: SYSTEM_CONFIGURATION,
             children: [
               {
@@ -257,7 +232,7 @@
           },
           {
             name: this.$t('admin.access_management'),
-            id: "accessmanagementMenu",
+            id: "accessmanagement",
             permission: ACCESS_MANAGEMENT,
             children: [
               {

--- a/src/views/administration/Administration.vue
+++ b/src/views/administration/Administration.vue
@@ -7,7 +7,7 @@
       <b-col xs="6" sm="8" md="8" lg="9">
         <div class="tab-content">
           <!-- Dynamically loads the selected admin plugin -->
-          <component class="animated fadeIn" :is="selectedComponent" :header="header" />
+          <router-view class="animated fadeIn" :header="header" />
         </div>
       </b-col>
     </b-row>

--- a/src/views/policy/PolicyManagement.vue
+++ b/src/views/policy/PolicyManagement.vue
@@ -39,26 +39,19 @@
         } else if (this.$route.fullPath !== '/policy' && this.$route.fullPath !== '/policy/') {
           this.$router.push({path: '/policy'})
         }
+      },
+      getTabFromRoute: function () {
+        let pattern = new RegExp("/policy\/([^\\/]*)", "gi");
+        let tab = pattern.exec(this.$route.fullPath.toLowerCase());
+        return this.$refs[tab && tab[1] ? tab[1].toLowerCase() : 'policies'];
       }
     },
     mounted() {
-      let pattern = new RegExp("/policy\/([^\\/]*)", "gi")
-      let tab = pattern.exec(this.$route.fullPath.toLowerCase())
-      if (tab && tab[1]) {
-        this.$refs[tab[1].toLowerCase()].active = true
-      } else {
-        this.$refs.policies.active = true
-      }
+      this.getTabFromRoute().active = true;
     },
     watch: {
       $route() {
-        let pattern = new RegExp("/policy\/([^\\/]*)", "gi")
-        let tab = pattern.exec(this.$route.fullPath.toLowerCase())
-        if (tab && tab[1]) {
-          this.$refs[tab[1].toLowerCase()].activate()
-        } else {
-          this.$refs.policies.activate()
-        }
+        this.getTabFromRoute().activate();
       }
     }
   }

--- a/src/views/policy/PolicyManagement.vue
+++ b/src/views/policy/PolicyManagement.vue
@@ -1,11 +1,11 @@
 <template>
   <div class="animated fadeIn" v-permission="PERMISSIONS.POLICY_MANAGEMENT">
     <b-tabs class="body-bg-color" style="border-left: 0; border-right:0; border-top:0 ">
-      <b-tab class="body-bg-color overview-chart" style="border-left: 0; border-right:0; border-top:0 " active>
+      <b-tab ref="policies" class="body-bg-color overview-chart" style="border-left: 0; border-right:0; border-top:0 " active @click="routeTo()">
         <template v-slot:title><i class="fa fa-list-alt"></i> {{ $t('message.policies') }} <b-badge variant="tab-total">{{ totalPolicies }}</b-badge></template>
         <policy-list v-on:total="totalPolicies = $event" />
       </b-tab>
-      <b-tab>
+      <b-tab ref="licensegroups" @click="routeTo('licenseGroups')">
         <template v-slot:title><i class="fa fa-balance-scale"></i> {{ $t('message.license_groups') }} <b-badge variant="tab-total">{{ totalLicenseGroups }}</b-badge></template>
         <license-group-list v-on:total="totalLicenseGroups = $event" />
       </b-tab>
@@ -28,6 +28,37 @@
       return {
         totalPolicies: 0,
         totalLicenseGroups: 0
+      }
+    },
+    methods: {
+      routeTo(path) {
+        if (path) {
+          if (!this.$route.fullPath.toLowerCase().includes('/' + path.toLowerCase())) {
+            this.$router.push({path: '/policy/' + path})
+          }
+        } else if (this.$route.fullPath !== '/policy' && this.$route.fullPath !== '/policy/') {
+          this.$router.push({path: '/policy'})
+        }
+      }
+    },
+    mounted() {
+      let pattern = new RegExp("/policy\/([^\\/]*)", "gi")
+      let tab = pattern.exec(this.$route.fullPath.toLowerCase())
+      if (tab && tab[1]) {
+        this.$refs[tab[1].toLowerCase()].active = true
+      } else {
+        this.$refs.policies.active = true
+      }
+    },
+    watch: {
+      $route() {
+        let pattern = new RegExp("/policy\/([^\\/]*)", "gi")
+        let tab = pattern.exec(this.$route.fullPath.toLowerCase())
+        if (tab && tab[1]) {
+          this.$refs[tab[1].toLowerCase()].activate()
+        } else {
+          this.$refs.policies.activate()
+        }
       }
     }
   }

--- a/src/views/portfolio/licenses/License.vue
+++ b/src/views/portfolio/licenses/License.vue
@@ -114,6 +114,11 @@
         } else if (this.$route.fullPath !== '/licenses/' + this.licenseId && this.$route.fullPath !== '/licenses/' + this.licenseId + '/') {
           this.$router.push({path: '/licenses/' + this.licenseId})
         }
+      },
+      getTabFromRoute: function () {
+        let pattern = new RegExp("/licenses\\/" + this.licenseId + "\\/([^\\/]*)", "gi");
+        let tab = pattern.exec(this.$route.fullPath.toLowerCase());
+        return this.$refs[tab && tab[1] ? tab[1].toLowerCase() : 'overview'];
       }
     },
     beforeMount() {
@@ -126,23 +131,11 @@
         EventBus.$emit('addCrumb', this.licenseLabel);
         this.$title = `${this.$t('message.license')} ${this.licenseLabel}`;
       });
-      let pattern = new RegExp("/licenses\\/" + this.licenseId + "\\/([^\\/]*)", "gi")
-      let tab = pattern.exec(this.$route.fullPath.toLowerCase())
-      if (tab && tab[1]) {
-        this.$refs[tab[1].toLowerCase()].active = true
-      } else {
-        this.$refs.overview.active = true
-      }
+      this.getTabFromRoute().active = true;
     },
     watch:{
       $route() {
-        let pattern = new RegExp("/licenses\\/" + this.licenseId + "\\/([^\\/]*)", "gi")
-        let tab = pattern.exec(this.$route.fullPath.toLowerCase())
-        if (tab && tab[1]) {
-          this.$refs[tab[1].toLowerCase()].activate()
-        } else {
-          this.$refs.overview.activate()
-        }
+        this.getTabFromRoute().activate();
       }
     },
     destroyed() {

--- a/src/views/portfolio/licenses/License.vue
+++ b/src/views/portfolio/licenses/License.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="animated fadeIn" v-permission="PERMISSIONS.VIEW_PORTFOLIO">
     <b-tabs class="body-bg-color" style="border-left: 0; border-right:0; border-top:0 ">
-      <b-tab class="body-bg-color overview-chart" style="border-left: 0; border-right:0; border-top:0 " active>
+      <b-tab ref="overview" class="body-bg-color overview-chart" style="border-left: 0; border-right:0; border-top:0 " active @click="routeTo()">
         <template v-slot:title>{{ $t('message.overview') }}</template>
         <table>
           <tr>
@@ -50,15 +50,15 @@
           </tr>
         </table>
       </b-tab>
-      <b-tab>
+      <b-tab ref="licensetext" @click="routeTo('licenseText')">
         <template v-slot:title>{{ $t('message.license_text') }}</template>
         <div class="licenseText formattedLicenseContent">{{ license.licenseText }}</div>
       </b-tab>
-      <b-tab>
+      <b-tab ref="template" @click="routeTo('template')">
         <template v-slot:title>{{ $t('message.template') }}</template>
         <div class="templateText formattedLicenseContent">{{ license.standardLicenseTemplate }}</div>
       </b-tab>
-      <b-tab>
+      <b-tab ref="header" @click="routeTo('header')">
         <template v-slot:title>{{ $t('message.source_header') }}</template>
         <div class="headerText formattedLicenseContent">{{ license.standardLicenseHeader }}</div>
       </b-tab>
@@ -105,6 +105,15 @@
         }).catch((error) => {
           this.$toastr.w(this.$t('condition.unsuccessful_action'));
         });
+      },
+      routeTo(path) {
+        if (path) {
+          if (!this.$route.fullPath.toLowerCase().includes('/' + path.toLowerCase())) {
+            this.$router.push({path: '/licenses/' + this.licenseId + '/' + path})
+          }
+        } else if (this.$route.fullPath !== '/licenses/' + this.licenseId && this.$route.fullPath !== '/licenses/' + this.licenseId + '/') {
+          this.$router.push({path: '/licenses/' + this.licenseId})
+        }
       }
     },
     beforeMount() {
@@ -117,6 +126,24 @@
         EventBus.$emit('addCrumb', this.licenseLabel);
         this.$title = `${this.$t('message.license')} ${this.licenseLabel}`;
       });
+      let pattern = new RegExp("/licenses\\/" + this.licenseId + "\\/([^\\/]*)", "gi")
+      let tab = pattern.exec(this.$route.fullPath.toLowerCase())
+      if (tab && tab[1]) {
+        this.$refs[tab[1].toLowerCase()].active = true
+      } else {
+        this.$refs.overview.active = true
+      }
+    },
+    watch:{
+      $route() {
+        let pattern = new RegExp("/licenses\\/" + this.licenseId + "\\/([^\\/]*)", "gi")
+        let tab = pattern.exec(this.$route.fullPath.toLowerCase())
+        if (tab && tab[1]) {
+          this.$refs[tab[1].toLowerCase()].activate()
+        } else {
+          this.$refs.overview.activate()
+        }
+      }
     },
     destroyed() {
       EventBus.$emit('crumble');

--- a/src/views/portfolio/projects/Component.vue
+++ b/src/views/portfolio/projects/Component.vue
@@ -79,11 +79,11 @@
       </div>
     </b-card>
     <b-tabs class="body-bg-color" style="border-left: 0; border-right:0; border-top:0 ">
-      <b-tab class="body-bg-color overview-chart" style="border-left: 0; border-right:0; border-top:0 " active>
+      <b-tab ref="overview" class="body-bg-color overview-chart" style="border-left: 0; border-right:0; border-top:0 " active @click="routeTo()">
         <template v-slot:title><i class="fa fa-line-chart"></i> {{ $t('message.overview') }}</template>
         <component-dashboard style="border-left: 0; border-right:0; border-top:0 "/>
       </b-tab>
-      <b-tab>
+      <b-tab ref="vulnerabilities" @click="routeTo('vulnerabilities')">
         <template v-slot:title><i class="fa fa-shield"></i> {{ $t('message.vulnerabilities') }} <b-badge variant="tab-total">{{ totalVulnerabilities }}</b-badge></template>
         <component-vulnerabilities :key="this.uuid" :uuid="this.uuid" v-on:total="totalVulnerabilities = $event" />
       </b-tab>
@@ -169,6 +169,15 @@
       redirectToDependencyGraph: function (){
         this.$router.push({path: "/projects/" + this.component.project.uuid + "/dependencyGraph/" + this.component.uuid})
       },
+      routeTo(path) {
+        if (path) {
+          if (!this.$route.fullPath.toLowerCase().includes('/' + path.toLowerCase())) {
+            this.$router.push({path: '/components/' + this.uuid + '/' + path})
+          }
+        } else if (this.$route.fullPath !== '/components/' + this.uuid && this.$route.fullPath !== '/components/' + this.uuid + '/') {
+          this.$router.push({path: '/components/' + this.uuid})
+        }
+      }
     },
     beforeMount() {
       this.uuid = this.$route.params.uuid;
@@ -190,6 +199,25 @@
         this.currentUnassigned = common.valueWithDefault(response.data.unassigned, 0);
         this.currentRiskScore = common.valueWithDefault(response.data.inheritedRiskScore, 0);
       });
+
+      let pattern = new RegExp("/components\\/" + this.uuid + "\\/([^\\/]*)", "gi")
+      let tab = pattern.exec(this.$route.fullPath.toLowerCase())
+      if (tab && tab[1]) {
+        this.$refs[tab[1].toLowerCase()].active = true
+      } else {
+        this.$refs.overview.active = true
+      }
+    },
+    watch:{
+      $route() {
+        let pattern = new RegExp("/components\\/" + this.uuid + "\\/([^\\/]*)", "gi")
+        let tab = pattern.exec(this.$route.fullPath.toLowerCase())
+        if (tab && tab[1]) {
+          this.$refs[tab[1].toLowerCase()].activate()
+        } else {
+          this.$refs.overview.activate()
+        }
+      }
     },
     destroyed() {
       EventBus.$emit('crumble');

--- a/src/views/portfolio/projects/Component.vue
+++ b/src/views/portfolio/projects/Component.vue
@@ -177,6 +177,11 @@
         } else if (this.$route.fullPath !== '/components/' + this.uuid && this.$route.fullPath !== '/components/' + this.uuid + '/') {
           this.$router.push({path: '/components/' + this.uuid})
         }
+      },
+      getTabFromRoute: function () {
+        let pattern = new RegExp("/components\\/" + this.uuid + "\\/([^\\/]*)", "gi");
+        let tab = pattern.exec(this.$route.fullPath.toLowerCase());
+        return this.$refs[tab && tab[1] ? tab[1].toLowerCase() : 'overview'];
       }
     },
     beforeMount() {
@@ -200,23 +205,11 @@
         this.currentRiskScore = common.valueWithDefault(response.data.inheritedRiskScore, 0);
       });
 
-      let pattern = new RegExp("/components\\/" + this.uuid + "\\/([^\\/]*)", "gi")
-      let tab = pattern.exec(this.$route.fullPath.toLowerCase())
-      if (tab && tab[1]) {
-        this.$refs[tab[1].toLowerCase()].active = true
-      } else {
-        this.$refs.overview.active = true
-      }
+      this.getTabFromRoute().active = true;
     },
     watch:{
       $route() {
-        let pattern = new RegExp("/components\\/" + this.uuid + "\\/([^\\/]*)", "gi")
-        let tab = pattern.exec(this.$route.fullPath.toLowerCase())
-        if (tab && tab[1]) {
-          this.$refs[tab[1].toLowerCase()].activate()
-        } else {
-          this.$refs.overview.activate()
-        }
+        this.getTabFromRoute().activate();
       }
     },
     destroyed() {

--- a/src/views/portfolio/projects/Project.vue
+++ b/src/views/portfolio/projects/Project.vue
@@ -96,31 +96,31 @@
       </div>
     </b-card>
     <b-tabs class="body-bg-color" style="border-left: 0; border-right:0; border-top:0 ">
-      <b-tab class="body-bg-color overview-chart" style="border-left: 0; border-right:0; border-top:0 " active>
+      <b-tab ref="overview" @click="routeTo()" class="body-bg-color overview-chart" style="border-left: 0; border-right:0; border-top:0 " active>
         <template v-slot:title><i class="fa fa-line-chart"></i> {{ $t('message.overview') }}</template>
         <project-dashboard :key="this.uuid" :uuid="this.uuid" :project="this.project" style="border-left: 0; border-right:0; border-top:0 "/>
       </b-tab>
-      <b-tab>
+      <b-tab ref="components" @click="routeTo('components')">
         <template v-slot:title><i class="fa fa-cubes"></i> {{ $t('message.components') }} <b-badge variant="tab-total">{{ totalComponents }}</b-badge></template>
         <project-components :key="this.uuid" :uuid="this.uuid" v-on:total="totalComponents = $event" />
       </b-tab>
-      <b-tab>
+      <b-tab ref="services" @click="routeTo('services')">
         <template v-slot:title><i class="fa fa-exchange"></i> {{ $t('message.services') }} <b-badge variant="tab-total">{{ totalServices }}</b-badge></template>
         <project-services :key="this.uuid" :uuid="this.uuid" v-on:total="totalServices = $event" />
       </b-tab>
-      <b-tab ref="tabDependencyGraph">
+      <b-tab ref="dependencygraph" @click="routeTo('dependencyGraph')">
         <template v-slot:title><i class="fa fa-sitemap"></i> {{ $t('message.dependency_graph') }} <b-badge variant="tab-total">{{ totalDependencyGraphs }}</b-badge></template>
         <project-dependency-graph :key="this.uuid" :uuid="this.uuid" :project="this.project" v-on:total="totalDependencyGraphs = $event" />
       </b-tab>
-      <b-tab v-if="isPermitted(PERMISSIONS.VIEW_VULNERABILITY)">
+      <b-tab ref="findings" v-if="isPermitted(PERMISSIONS.VIEW_VULNERABILITY)" @click="routeTo('findings')">
         <template v-slot:title><i class="fa fa-tasks"></i> {{ $t('message.audit_vulnerabilities') }} <b-badge variant="tab-total">{{ totalFindings }}</b-badge></template>
         <project-findings :key="this.uuid" :uuid="this.uuid" v-on:total="totalFindings = $event" />
       </b-tab>
-      <b-tab v-if="isPermitted(PERMISSIONS.VIEW_VULNERABILITY)">
+      <b-tab ref="epss" v-if="isPermitted(PERMISSIONS.VIEW_VULNERABILITY)" @click="routeTo('epss')">
         <template v-slot:title><i class="fa fa-tasks"></i> {{ $t('message.exploit_predictions') }} <b-badge variant="tab-total">{{ totalEpss }}</b-badge></template>
         <project-epss :key="this.uuid" :uuid="this.uuid" v-on:total="totalEpss = $event" />
       </b-tab>
-      <b-tab v-if="isPermitted(PERMISSIONS.VIEW_POLICY_VIOLATION)">
+      <b-tab ref="policyviolations" v-if="isPermitted(PERMISSIONS.VIEW_POLICY_VIOLATION)" @click="routeTo('policyViolations')">
         <template v-slot:title><i class="fa fa-fire"></i> {{ $t('message.policy_violations') }} <b-badge variant="tab-total">{{ totalViolations }}</b-badge></template>
         <project-policy-violations :key="this.uuid" :uuid="this.uuid" v-on:total="totalViolations = $event" />
       </b-tab>
@@ -244,6 +244,15 @@
       },
       initializeProjectDetailsModal: function () {
         this.$root.$emit('initializeProjectDetailsModal')
+      },
+      routeTo(path) {
+        if (path) {
+          if (!this.$route.fullPath.toLowerCase().includes('/' + path.toLowerCase())) {
+            this.$router.push({path: '/projects/' + this.uuid + '/' + path})
+          }
+        } else if (this.$route.fullPath !== '/projects/' + this.uuid && this.$route.fullPath !== '/projects/' + this.uuid + '/') {
+          this.$router.push({path: '/projects/' + this.uuid})
+        }
       }
     },
     beforeMount() {
@@ -251,16 +260,41 @@
       this.initialize();
     },
     mounted() {
-      if (this.$route.params.componentUuid){
-        this.$refs.tabDependencyGraph.active = true
+      try {
+        if (this.$route.params.componentUuid){
+          this.$refs.dependencygraph.active = true
+        } else {
+          let pattern = new RegExp("/projects\\/" + this.uuid + "\\/([^\\/]*)", "gi")
+          let tab = pattern.exec(this.$route.fullPath.toLowerCase())
+          if (tab && tab[1]) {
+            this.$refs[tab[1].toLowerCase()].active = true
+          } else {
+            this.$refs.overview.active = true
+          }
+        }
+      } catch (e) {
+        this.$toastr.e(this.$t('condition.forbidden'));
+        this.$router.replace({path: '/projects/' + this.uuid})
+        this.$refs.overview.active = true
       }
+
     },
     watch:{
       $route (to, from){
         this.uuid = this.$route.params.uuid;
-        this.initialize();
+        if (to.params.uuid !== from.params.uuid) {
+          this.initialize();
+        }
         if (this.$route.params.componentUuid){
-          this.$refs.tabDependencyGraph.activate()
+          this.$refs.dependencygraph.activate()
+          this.initialize();
+        }
+        let pattern = new RegExp("/projects\\/" + this.uuid + "\\/([^\\/]*)", "gi")
+        let tab = pattern.exec(this.$route.fullPath.toLowerCase())
+        if (tab && tab[1]) {
+          this.$refs[tab[1].toLowerCase()].activate()
+        } else {
+          this.$refs.overview.activate()
         }
       }
     },

--- a/src/views/portfolio/projects/Project.vue
+++ b/src/views/portfolio/projects/Project.vue
@@ -252,11 +252,16 @@
       routeTo(path) {
         if (path) {
           if (!this.$route.fullPath.toLowerCase().includes('/' + path.toLowerCase())) {
-            this.$router.push({path: '/projects/' + this.uuid + '/' + path})
+            this.$router.push({path: '/projects/' + this.uuid + '/' + path});
           }
         } else if (this.$route.fullPath !== '/projects/' + this.uuid && this.$route.fullPath !== '/projects/' + this.uuid + '/') {
-          this.$router.push({path: '/projects/' + this.uuid})
+          this.$router.push({path: '/projects/' + this.uuid});
         }
+      },
+      getTabFromRoute: function () {
+        let pattern = new RegExp("/projects\\/" + this.uuid + "\\/([^\\/]*)", "gi");
+        let tab = pattern.exec(this.$route.fullPath.toLowerCase());
+        return this.$refs[(tab && tab[1]) ? tab[1].toLowerCase() : 'overview'];
       }
     },
     beforeMount() {
@@ -266,40 +271,26 @@
     mounted() {
       try {
         if (this.$route.params.componentUuid){
-          this.$refs.dependencygraph.active = true
+          this.$refs.dependencygraph.active = true;
         } else {
-          let pattern = new RegExp("/projects\\/" + this.uuid + "\\/([^\\/]*)", "gi")
-          let tab = pattern.exec(this.$route.fullPath.toLowerCase())
-          if (tab && tab[1]) {
-            this.$refs[tab[1].toLowerCase()].active = true
-          } else {
-            this.$refs.overview.active = true
-          }
+          this.getTabFromRoute().active = true;
         }
       } catch (e) {
         this.$toastr.e(this.$t('condition.forbidden'));
-        this.$router.replace({path: '/projects/' + this.uuid})
-        this.$refs.overview.active = true
+        this.$router.replace({path: '/projects/' + this.uuid});
+        this.$refs.overview.active = true;
       }
-
     },
     watch:{
       $route (to, from){
         this.uuid = this.$route.params.uuid;
         if (to.params.uuid !== from.params.uuid) {
           this.initialize();
-        }
-        if (this.$route.params.componentUuid){
-          this.$refs.dependencygraph.activate()
+        } else if (this.$route.params.componentUuid){
           this.initialize();
+          this.$refs.dependencygraph.activate();
         }
-        let pattern = new RegExp("/projects\\/" + this.uuid + "\\/([^\\/]*)", "gi")
-        let tab = pattern.exec(this.$route.fullPath.toLowerCase())
-        if (tab && tab[1]) {
-          this.$refs[tab[1].toLowerCase()].activate()
-        } else {
-          this.$refs.overview.activate()
-        }
+        this.getTabFromRoute().activate();
       }
     },
     destroyed() {

--- a/src/views/portfolio/projects/Project.vue
+++ b/src/views/portfolio/projects/Project.vue
@@ -222,7 +222,11 @@
       },
       initialize: function() {
         let projectUrl = `${this.$api.BASE_URL}/${this.$api.URL_PROJECT}/${this.uuid}`;
-        this.axios.get(projectUrl).then((response) => {
+        this.axios.get(projectUrl).catch((error) => {
+          if (error.response.status === 403) {
+            this.$router.replace({name: "Projects"})
+          }
+        }).then((response) => {
           this.project = response.data;
           let projectVersionsUrl = `${this.$api.BASE_URL}/${this.$api.URL_PROJECT}?offset=0&limit=10&excludeInactive=true&name=` + encodeURIComponent(this.project.name);
           this.axios.get(projectVersionsUrl).then((response) => {

--- a/src/views/portfolio/projects/ProjectDependencyGraph.vue
+++ b/src/views/portfolio/projects/ProjectDependencyGraph.vue
@@ -129,13 +129,15 @@ export default {
           fetchedChildren: true,
           expand: true
         }
-        new Promise(resolve => setTimeout(resolve, 50)).then(() => {
-          document.getElementsByClassName("searched").item(0).scrollIntoView({
-            behavior: "smooth",
-            inline: "center",
-            block: "center"
+        if (this.$route.params.componentUuid) {
+          new Promise(resolve => setTimeout(resolve, 50)).then(() => {
+            document.getElementsByClassName("searched").item(0).scrollIntoView({
+              behavior: "smooth",
+              inline: "center",
+              block: "center"
+            })
           })
-        })
+        }
       } else {
         this.data = {
           id: this.nodeId,
@@ -146,6 +148,11 @@ export default {
           expand: true
         }
       }
+    },
+    $route: function () {
+      this.showCompleteGraph = true
+      this.collapse(this.data.children)
+      this.data.expand = false
     }
   },
   methods: {
@@ -217,19 +224,21 @@ export default {
     },
     transformDependenciesToOrgTreeWithSearchedDependency: function (dependencies, treeNode, onlySearched) {
       let children = []
-      let directDependencies = JSON.parse(this.project.directDependencies)
-      directDependencies.forEach((directDependency) => {
-        if (dependencies[directDependency.uuid] && (!onlySearched || (onlySearched && (dependencies[directDependency.uuid].expandDependencyGraph || directDependency.uuid === this.$route.params.componentUuid)))) {
-          let childNode = this.transformDependencyToOrgTreeWithSearchedDependency(dependencies[directDependency.uuid])
-          childNode.gatheredKeys.push(childNode.label)
-          children.push(childNode)
-          if (onlySearched && directDependency.uuid === this.$route.params.componentUuid) {
-            this.$set(childNode, 'children', this.getChildrenFromDependencyWithSearchedDependency(dependencies, dependencies[directDependency.uuid], childNode, false))
-          } else {
-            this.$set(childNode, 'children', this.getChildrenFromDependencyWithSearchedDependency(dependencies, dependencies[directDependency.uuid], childNode, onlySearched))
+      if (dependencies) {
+        let directDependencies = JSON.parse(this.project.directDependencies)
+        directDependencies.forEach((directDependency) => {
+          if (dependencies[directDependency.uuid] && (!onlySearched || (onlySearched && (dependencies[directDependency.uuid].expandDependencyGraph || directDependency.uuid === this.$route.params.componentUuid)))) {
+            let childNode = this.transformDependencyToOrgTreeWithSearchedDependency(dependencies[directDependency.uuid])
+            childNode.gatheredKeys.push(childNode.label)
+            children.push(childNode)
+            if (onlySearched && directDependency.uuid === this.$route.params.componentUuid) {
+              this.$set(childNode, 'children', this.getChildrenFromDependencyWithSearchedDependency(dependencies, dependencies[directDependency.uuid], childNode, false))
+            } else {
+              this.$set(childNode, 'children', this.getChildrenFromDependencyWithSearchedDependency(dependencies, dependencies[directDependency.uuid], childNode, onlySearched))
+            }
           }
-        }
-      })
+        })
+      }
       return children
     },
     getChildrenFromDependencyWithSearchedDependency: function (dependencies, component, treeNode, onlySearched) {

--- a/src/views/portfolio/vulnerabilities/Vulnerability.vue
+++ b/src/views/portfolio/vulnerabilities/Vulnerability.vue
@@ -48,7 +48,7 @@
     </div>
 
     <b-tabs class="body-bg-color" style="border-left: 0; border-right:0; border-top:0 ">
-      <b-tab class="body-bg-color overview-chart" style="border-left: 0; border-right:0; border-top:0 " active>
+      <b-tab ref="overview" class="body-bg-color overview-chart" style="border-left: 0; border-right:0; border-top:0 " active @click="routeTo()">
         <template v-slot:title><i class="fa fa-line-chart"></i> {{ $t('message.overview') }}</template>
 
         <div v-if="vulnerability.description">
@@ -138,7 +138,7 @@
         </div>
 
       </b-tab>
-      <b-tab v-if="isPermitted(PERMISSIONS.VIEW_VULNERABILITY)">
+      <b-tab ref="affectedprojects" v-if="isPermitted(PERMISSIONS.VIEW_VULNERABILITY)" @click="routeTo('affectedProjects')">
         <template v-slot:title><i class="fa fa-tasks"></i> {{ $t('message.affected_projects') }} <b-badge variant="tab-total">{{ totalAffectedProjects }}</b-badge></template>
         <affected-projects :key="this.uuid" :source="source" :vulnId="vulnId" v-on:total="totalAffectedProjects = $event" />
       </b-tab>
@@ -304,6 +304,15 @@
         this.uuid = this.$route.params.uuid;
         this.source = this.$route.params.source;
         this.vulnId = this.$route.params.vulnId;
+      },
+      routeTo(path) {
+        if (path) {
+          if (!this.$route.fullPath.toLowerCase().includes('/' + path.toLowerCase())) {
+            this.$router.push({path: '/vulnerabilities/' + this.source + "/" + this.vulnId + '/' + path})
+          }
+        } else if (this.$route.fullPath !== '/vulnerabilities/' + this.source + "/" + this.vulnId && this.$route.fullPath !== '/vulnerabilities/' + this.source + "/" + this.vulnId + '/') {
+          this.$router.push({path: '/vulnerabilities/' + this.source + "/" + this.vulnId + '/'})
+        }
       }
     },
     watch: {
@@ -316,6 +325,15 @@
         EventBus.$emit('crumble');
         this.initializeData();
         this.loadData();
+      },
+      $route() {
+        let pattern = new RegExp("/vulnerabilities\\/" + this.source + "\\/" + this.vulnId + "\\/([^\\/]*)", "gi")
+        let tab = pattern.exec(this.$route.fullPath.toLowerCase())
+        if (tab && tab[1]) {
+          this.$refs[tab[1].toLowerCase()].activate()
+        } else {
+          this.$refs.overview.activate()
+        }
       }
     },
     beforeMount() {
@@ -323,6 +341,13 @@
     },
     mounted() {
       this.loadData();
+      let pattern = new RegExp("/vulnerabilities\\/" + this.source + "\\/" + this.vulnId + "\\/([^\\/]*)", "gi")
+      let tab = pattern.exec(this.$route.fullPath.toLowerCase())
+      if (tab && tab[1]) {
+        this.$refs[tab[1].toLowerCase()].active = true
+      } else {
+        this.$refs.overview.active = true
+      }
     },
     destroyed() {
       EventBus.$emit('crumble');

--- a/src/views/portfolio/vulnerabilities/Vulnerability.vue
+++ b/src/views/portfolio/vulnerabilities/Vulnerability.vue
@@ -341,11 +341,17 @@
     },
     mounted() {
       this.loadData();
-      let pattern = new RegExp("/vulnerabilities\\/" + this.source + "\\/" + this.vulnId + "\\/([^\\/]*)", "gi")
-      let tab = pattern.exec(this.$route.fullPath.toLowerCase())
-      if (tab && tab[1]) {
-        this.$refs[tab[1].toLowerCase()].active = true
-      } else {
+      try {
+        let pattern = new RegExp("/vulnerabilities\\/" + this.source + "\\/" + this.vulnId + "\\/([^\\/]*)", "gi")
+        let tab = pattern.exec(this.$route.fullPath.toLowerCase())
+        if (tab && tab[1]) {
+          this.$refs[tab[1].toLowerCase()].active = true
+        } else {
+          this.$refs.overview.active = true
+        }
+      } catch (e) {
+        this.$toastr.e(this.$t('condition.forbidden'));
+        this.$router.replace({path: '/vulnerabilities/' + this.source + "/" + this.vulnId + '/'})
         this.$refs.overview.active = true
       }
     },

--- a/src/views/portfolio/vulnerabilities/Vulnerability.vue
+++ b/src/views/portfolio/vulnerabilities/Vulnerability.vue
@@ -313,6 +313,11 @@
         } else if (this.$route.fullPath !== '/vulnerabilities/' + this.source + "/" + this.vulnId && this.$route.fullPath !== '/vulnerabilities/' + this.source + "/" + this.vulnId + '/') {
           this.$router.push({path: '/vulnerabilities/' + this.source + "/" + this.vulnId + '/'})
         }
+      },
+      getTabFromRoute: function () {
+        let pattern = new RegExp("/vulnerabilities\\/" + this.source + "\\/" + this.vulnId + "\\/([^\\/]*)", "gi");
+        let tab = pattern.exec(this.$route.fullPath.toLowerCase());
+        return this.$refs[tab && tab[1] ? tab[1].toLowerCase() : 'overview'];
       }
     },
     watch: {
@@ -327,13 +332,7 @@
         this.loadData();
       },
       $route() {
-        let pattern = new RegExp("/vulnerabilities\\/" + this.source + "\\/" + this.vulnId + "\\/([^\\/]*)", "gi")
-        let tab = pattern.exec(this.$route.fullPath.toLowerCase())
-        if (tab && tab[1]) {
-          this.$refs[tab[1].toLowerCase()].activate()
-        } else {
-          this.$refs.overview.activate()
-        }
+        this.getTabFromRoute().activate();
       }
     },
     beforeMount() {
@@ -342,13 +341,7 @@
     mounted() {
       this.loadData();
       try {
-        let pattern = new RegExp("/vulnerabilities\\/" + this.source + "\\/" + this.vulnId + "\\/([^\\/]*)", "gi")
-        let tab = pattern.exec(this.$route.fullPath.toLowerCase())
-        if (tab && tab[1]) {
-          this.$refs[tab[1].toLowerCase()].active = true
-        } else {
-          this.$refs.overview.active = true
-        }
+        this.getTabFromRoute().active = true;
       } catch (e) {
         this.$toastr.e(this.$t('condition.forbidden'));
         this.$router.replace({path: '/vulnerabilities/' + this.source + "/" + this.vulnId + '/'})


### PR DESCRIPTION
### Description

This PR introduces a new routing behavior, which allows to link to nested components, like for example:
- components tab of a project (`/projects/<projectUuid>/components`)
- affected projects tab of a vulnerability (`/vulnerabilities/<source>/<vulnId>/affectedProjects`)
- maven configuration in the admin menu (`/admin/repositories/maven`)

It also checks if the user has the right permissions (including ACL), to view the content behind the deep link. 
If the user does not have the right permissions, they will be redirected to other views, depending on the component.

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

### Addressed Issue

Didn't find an issue for this, probably needs to be created, before submitting the PR.

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details

**Example of the new routing in the project view:**

![Recording 2023-01-16 at 16 27 56](https://user-images.githubusercontent.com/113189967/212714073-616cc15d-6c2f-4935-8cd2-dd44bd270ff9.gif)

**Example of the new routing in the admin menu:**

![Recording 2023-01-16 at 16 36 38](https://user-images.githubusercontent.com/113189967/212715748-e13f5d2c-a2b7-4880-934d-fb916ff3cc8f.gif)

**Examples of route redirect, when correct permissions are missing**:

![Recording 2023-01-16 at 16 46 04](https://user-images.githubusercontent.com/113189967/212717817-693c32ac-dabc-4344-a1b9-1fb96bda9f38.gif)

![Recording 2023-01-16 at 16 40 02](https://user-images.githubusercontent.com/113189967/212716533-9a6d5df0-22fb-4f22-8133-a537fcfb8d45.gif)


<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/github-templates/CONTRIBUTING.md#pull-requests)
- ~[ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
