### PR TITLE
Remember user preferences for different views

### DIFF
--- a/src/shared/utils.js
+++ b/src/shared/utils.js
@@ -1,3 +1,5 @@
+import common from "@/shared/common";
+
 export function random (min, max) {
   return Math.floor(Math.random() * (max - min + 1) + min);
 }
@@ -66,4 +68,10 @@ export function getContextPath() {
     // App is deployed in a non-root context. Return the context.
     return window.location.pathname.substring(0, window.location.pathname.indexOf("/",2));
   }
+}
+
+export function loadUserPreferencesForBootstrapTable(_this, id, columns) {
+  columns.forEach((column) => {
+    _this.$set(column, "visible", (localStorage && localStorage.getItem(id + "Show" + common.capitalize(column.field)) !== null) ? (localStorage.getItem(id + "Show" + common.capitalize(column.field)) === "true") : column.visible);
+  })
 }

--- a/src/views/policy/LicenseGroupList.vue
+++ b/src/views/policy/LicenseGroupList.vue
@@ -82,7 +82,7 @@
           sidePagination: 'server',
           queryParamsType: 'pageSize',
           pageList: '[10, 25, 50, 100]',
-          pageSize: 10,
+          pageSize: (localStorage && localStorage.getItem("LicenseGroupListPageSize") !== null) ? Number(localStorage.getItem("LicenseGroupListPageSize")) : 10,
           icons: {
             refresh: 'fa-refresh'
           },
@@ -198,7 +198,12 @@
             res.total = xhr.getResponseHeader("X-Total-Count");
             return res;
           },
-          url: `${this.$api.BASE_URL}/${this.$api.URL_LICENSE_GROUP}`
+          url: `${this.$api.BASE_URL}/${this.$api.URL_LICENSE_GROUP}`,
+          onPageChange: ((number, size) => {
+            if (localStorage) {
+              localStorage.setItem("LicenseGroupListPageSize", size.toString())
+            }
+          }),
         }
       };
     }

--- a/src/views/policy/PolicyList.vue
+++ b/src/views/policy/PolicyList.vue
@@ -88,7 +88,7 @@
           sidePagination: 'server',
           queryParamsType: 'pageSize',
           pageList: '[10, 25, 50, 100]',
-          pageSize: 10,
+          pageSize: (localStorage && localStorage.getItem("PolicyListPageSize") !== null) ? Number(localStorage.getItem("PolicyListPageSize")) : 10,
           icons: {
             refresh: 'fa-refresh'
           },
@@ -348,7 +348,12 @@
             res.total = xhr.getResponseHeader("X-Total-Count");
             return res;
           },
-          url: `${this.$api.BASE_URL}/${this.$api.URL_POLICY}`
+          url: `${this.$api.BASE_URL}/${this.$api.URL_POLICY}`,
+          onPageChange: ((number, size) => {
+            if (localStorage) {
+              localStorage.setItem("PolicyListPageSize", size.toString())
+            }
+          }),
         }
       };
     }

--- a/src/views/portfolio/licenses/LicenseList.vue
+++ b/src/views/portfolio/licenses/LicenseList.vue
@@ -10,7 +10,8 @@
       ref="table"
       :columns="columns"
       :data="data"
-      :options="options">
+      :options="options"
+      @on-load-success="onLoadSuccess">
     </bootstrap-table>
     <license-add-license-modal v-on:refreshTable="refreshTable"/>
   </div>
@@ -22,6 +23,7 @@
   import xssFilters from "xss-filters";
   import permissionsMixin from "../../../mixins/permissionsMixin";
   import LicenseAddLicenseModal from "@/views/portfolio/licenses/LicenseAddLicenseModal";
+  import {loadUserPreferencesForBootstrapTable} from "@/shared/utils";
 
   export default {
     mixins: [permissionsMixin],
@@ -35,6 +37,9 @@
           url: `${this.$api.BASE_URL}/${this.$api.URL_LICENSE}`,
           silent: true
         })
+      },
+      onLoadSuccess: function () {
+        loadUserPreferencesForBootstrapTable(this, "LicenseList", this.$refs.table.columns);
       }
     },
     data() {
@@ -99,7 +104,9 @@
           sidePagination: 'server',
           queryParamsType: 'pageSize',
           pageList: '[10, 25, 50, 100]',
-          pageSize: 10,
+          pageSize: (localStorage && localStorage.getItem("LicenseListPageSize") !== null) ? Number(localStorage.getItem("LicenseListPageSize")) : 10,
+          sortName: (localStorage && localStorage.getItem("LicenseListSortName") !== null) ? localStorage.getItem("LicenseListSortName") : undefined,
+          sortOrder: (localStorage && localStorage.getItem("LicenseListSortOrder") !== null) ? localStorage.getItem("LicenseListSortOrder") : undefined,
           icons: {
             refresh: 'fa-refresh'
           },
@@ -108,7 +115,23 @@
             res.total = xhr.getResponseHeader("X-Total-Count");
             return res;
           },
-          url: `${this.$api.BASE_URL}/${this.$api.URL_LICENSE}`
+          url: `${this.$api.BASE_URL}/${this.$api.URL_LICENSE}`,
+          onPageChange: ((number, size) => {
+            if (localStorage) {
+              localStorage.setItem("LicenseListPageSize", size.toString())
+            }
+          }),
+          onColumnSwitch: ((field, checked) => {
+            if (localStorage) {
+              localStorage.setItem("LicenseListShow"+common.capitalize(field), checked.toString())
+            }
+          }),
+          onSort: ((name, order) => {
+            if (localStorage) {
+              localStorage.setItem("LicenseListSortName", name);
+              localStorage.setItem("LicenseListSortOrder", order);
+            }
+          })
         }
       };
     }

--- a/src/views/portfolio/projects/ComponentVulnerabilities.vue
+++ b/src/views/portfolio/projects/ComponentVulnerabilities.vue
@@ -16,6 +16,7 @@
   import xssFilters from "xss-filters";
   import BootstrapToggle from 'vue-bootstrap-toggle'
   import permissionsMixin from "../../../mixins/permissionsMixin";
+  import {loadUserPreferencesForBootstrapTable} from "@/shared/utils";
 
   export default {
     props: {
@@ -129,7 +130,9 @@
           sidePagination: 'server',
           queryParamsType: 'pageSize',
           pageList: '[10, 25, 50, 100]',
-          pageSize: 10,
+          pageSize: (localStorage && localStorage.getItem("ComponentVulnerabilitiesPageSize") !== null) ? Number(localStorage.getItem("ComponentVulnerabilitiesPageSize")) : 10,
+          sortName: (localStorage && localStorage.getItem("ComponentVulnerabilitiesSortName") !== null) ? localStorage.getItem("ComponentVulnerabilitiesSortName") : undefined,
+          sortOrder: (localStorage && localStorage.getItem("ComponentVulnerabilitiesSortOrder") !== null) ? localStorage.getItem("ComponentVulnerabilitiesSortOrder") : undefined,
           icons: {
             refresh: 'fa-refresh'
           },
@@ -138,12 +141,29 @@
             res.total = xhr.getResponseHeader("X-Total-Count");
             return res;
           },
-          url: `${this.$api.BASE_URL}/${this.$api.URL_VULNERABILITY}/component/${this.uuid}`
+          url: `${this.$api.BASE_URL}/${this.$api.URL_VULNERABILITY}/component/${this.uuid}`,
+          onPageChange: ((number, size) => {
+            if (localStorage) {
+              localStorage.setItem("ComponentVulnerabilitiesPageSize", size.toString())
+            }
+          }),
+          onColumnSwitch: ((field, checked) => {
+            if (localStorage) {
+              localStorage.setItem("ComponentVulnerabilitiesShow"+common.capitalize(field), checked.toString())
+            }
+          }),
+          onSort: ((name, order) => {
+            if (localStorage) {
+              localStorage.setItem("ComponentVulnerabilitiesSortName", name);
+              localStorage.setItem("ComponentVulnerabilitiesSortOrder", order);
+            }
+          })
         }
       };
     },
     methods: {
       tableLoaded: function(data) {
+        loadUserPreferencesForBootstrapTable(this, "ComponentVulnerabilities", this.$refs.table.columns);
         if (data && Object.prototype.hasOwnProperty.call(data, "total")) {
           this.$emit('total', data.total);
         } else {

--- a/src/views/portfolio/projects/ProjectComponents.vue
+++ b/src/views/portfolio/projects/ProjectComponents.vue
@@ -48,6 +48,7 @@
   import permissionsMixin from "../../../mixins/permissionsMixin";
   import ProjectAddComponentModal from "@/views/portfolio/projects/ProjectAddComponentModal";
   import ProjectUploadBomModal from "@/views/portfolio/projects/ProjectUploadBomModal";
+  import {loadUserPreferencesForBootstrapTable} from "@/shared/utils";
 
   export default {
     components: {ProjectUploadBomModal, ProjectAddComponentModal},
@@ -177,7 +178,9 @@
           toolbar: '#componentsToolbar',
           queryParamsType: 'pageSize',
           pageList: '[10, 25, 50, 100]',
-          pageSize: 10,
+          pageSize: (localStorage && localStorage.getItem("ProjectComponentsPageSize") !== null) ? Number(localStorage.getItem("ProjectComponentsPageSize")) : 10,
+          sortName: (localStorage && localStorage.getItem("ProjectComponentsSortName") !== null) ? localStorage.getItem("ProjectComponentsSortName") : undefined,
+          sortOrder: (localStorage && localStorage.getItem("ProjectComponentsSortOrder") !== null) ? localStorage.getItem("ProjectComponentsSortOrder") : undefined,
           icons: {
             refresh: 'fa-refresh'
           },
@@ -185,7 +188,23 @@
             res.total = xhr.getResponseHeader("X-Total-Count");
             return res;
           },
-          url: `${this.$api.BASE_URL}/${this.$api.URL_COMPONENT}/project/${this.uuid}`
+          url: `${this.$api.BASE_URL}/${this.$api.URL_COMPONENT}/project/${this.uuid}`,
+          onPageChange: ((number, size) => {
+            if (localStorage) {
+              localStorage.setItem("ProjectComponentsPageSize", size.toString())
+            }
+          }),
+          onColumnSwitch: ((field, checked) => {
+            if (localStorage) {
+              localStorage.setItem("ProjectComponentsShow"+common.capitalize(field), checked.toString())
+            }
+          }),
+          onSort: ((name, order) => {
+            if (localStorage) {
+              localStorage.setItem("ProjectComponentsSortName", name);
+              localStorage.setItem("ProjectComponentsSortOrder", order);
+            }
+          })
         }
       };
     },
@@ -239,6 +258,7 @@
         });
       },
       tableLoaded: function(data) {
+        loadUserPreferencesForBootstrapTable(this, "ProjectComponents", this.$refs.table.columns);
         if (data && Object.prototype.hasOwnProperty.call(data, "total")) {
           this.$emit('total', data.total);
         } else {

--- a/src/views/portfolio/projects/ProjectList.vue
+++ b/src/views/portfolio/projects/ProjectList.vue
@@ -13,7 +13,7 @@
       :columns="columns"
       :data="data"
       :options="options"
-      @on-load-success="onLoadSuccess()"
+      @on-load-success="onLoadSuccess"
       @on-pre-body="onPreBody"
       @on-post-body="onPostBody">
     </bootstrap-table>

--- a/src/views/portfolio/projects/ProjectServices.vue
+++ b/src/views/portfolio/projects/ProjectServices.vue
@@ -17,6 +17,7 @@ import common from "../../../shared/common";
 import SeverityProgressBar from "../../components/SeverityProgressBar";
 import xssFilters from "xss-filters";
 import permissionsMixin from "../../../mixins/permissionsMixin";
+import {loadUserPreferencesForBootstrapTable} from "@/shared/utils";
 
 export default {
   mixins: [permissionsMixin],
@@ -111,7 +112,9 @@ export default {
         toolbar: '#servicesToolbar',
         queryParamsType: 'pageSize',
         pageList: '[10, 25, 50, 100]',
-        pageSize: 10,
+        pageSize: (localStorage && localStorage.getItem("ProjectServicesPageSize") !== null) ? Number(localStorage.getItem("ProjectServicesPageSize")) : 10,
+        sortName: (localStorage && localStorage.getItem("ProjectServicesSortName") !== null) ? localStorage.getItem("ProjectServicesSortName") : undefined,
+        sortOrder: (localStorage && localStorage.getItem("ProjectServicesSortOrder") !== null) ? localStorage.getItem("ProjectServicesSortOrder") : undefined,
         icons: {
           refresh: 'fa-refresh'
         },
@@ -119,7 +122,23 @@ export default {
           res.total = xhr.getResponseHeader("X-Total-Count");
           return res;
         },
-        url: `${this.$api.BASE_URL}/${this.$api.URL_SERVICE}/project/${this.uuid}`
+        url: `${this.$api.BASE_URL}/${this.$api.URL_SERVICE}/project/${this.uuid}`,
+        onPageChange: ((number, size) => {
+          if (localStorage) {
+            localStorage.setItem("ProjectServicesPageSize", size.toString())
+          }
+        }),
+        onColumnSwitch: ((field, checked) => {
+          if (localStorage) {
+            localStorage.setItem("ProjectServicesShow"+common.capitalize(field), checked.toString())
+          }
+        }),
+        onSort: ((name, order) => {
+          if (localStorage) {
+            localStorage.setItem("ProjectServicesSortName", name);
+            localStorage.setItem("ProjectServicesSortOrder", order);
+          }
+        })
       }
     };
   },
@@ -142,6 +161,7 @@ export default {
       this.$refs.table.uncheckAll();
     },
     tableLoaded: function(data) {
+      loadUserPreferencesForBootstrapTable(this, "ProjectServices", this.$refs.table.columns);
       if (data && Object.prototype.hasOwnProperty.call(data, "total")) {
         this.$emit('total', data.total);
       } else {

--- a/src/views/portfolio/vulnerabilities/VulnerabilityList.vue
+++ b/src/views/portfolio/vulnerabilities/VulnerabilityList.vue
@@ -10,7 +10,8 @@
       ref="table"
       :columns="columns"
       :data="data"
-      :options="options">
+      :options="options"
+      @on-load-success="onLoadSuccess">
     </bootstrap-table>
     <vulnerability-create-vulnerability-modal v-on:refreshTable="refreshTable"/>
   </div>
@@ -23,6 +24,7 @@
   import xssFilters from "xss-filters";
   import permissionsMixin from "../../../mixins/permissionsMixin";
   import $ from "jquery";
+  import {loadUserPreferencesForBootstrapTable} from "@/shared/utils";
 
   export default {
     mixins: [permissionsMixin],
@@ -43,6 +45,9 @@
       initializeTooltips: function () {
         $('[data-toggle="tooltip"]').tooltip();
       },
+      onLoadSuccess: function () {
+        loadUserPreferencesForBootstrapTable(this, "VulnerabilityList", this.$refs.table.columns);
+      }
     },
     data() {
       return {
@@ -112,7 +117,9 @@
           sidePagination: 'server',
           queryParamsType: 'pageSize',
           pageList: '[10, 25, 50, 100]',
-          pageSize: 10,
+          pageSize: (localStorage && localStorage.getItem("VulnerabilityListPageSize") !== null) ? Number(localStorage.getItem("VulnerabilityListPageSize")) : 10,
+          sortName: (localStorage && localStorage.getItem("VulnerabilityListSortName") !== null) ? localStorage.getItem("VulnerabilityListSortName") : undefined,
+          sortOrder: (localStorage && localStorage.getItem("VulnerabilityListSortOrder") !== null) ? localStorage.getItem("VulnerabilityListSortOrder") : undefined,
           icons: {
             refresh: 'fa-refresh'
           },
@@ -121,7 +128,23 @@
             res.total = xhr.getResponseHeader("X-Total-Count");
             return res;
           },
-          url: this.apiUrl()
+          url: this.apiUrl(),
+          onPageChange: ((number, size) => {
+            if (localStorage) {
+              localStorage.setItem("VulnerabilityListPageSize", size.toString())
+            }
+          }),
+          onColumnSwitch: ((field, checked) => {
+            if (localStorage) {
+              localStorage.setItem("VulnerabilityListShow"+common.capitalize(field), checked.toString())
+            }
+          }),
+          onSort: ((name, order) => {
+            if (localStorage) {
+              localStorage.setItem("VulnerabilityListSortName", name);
+              localStorage.setItem("VulnerabilityListSortOrder", order);
+            }
+          })
         }
       };
     }


### PR DESCRIPTION
### Description

This PR saves adjustable user preferences, like the number of entries shown in a table, the visible columns, the sort order or the state of toggles, for every view in the local storage of the browser and then automatically sets those preferences when a view is opened again (e.g. license list, vulnerability list of a project, component search, ...).

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

### Addressed Issue

348

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details

![Recording 2023-01-25 at 09 37 48](https://user-images.githubusercontent.com/113189967/214516673-0d9c6cd0-d3bb-4a81-8d1d-0525f35a2ab5.gif)

![Recording 2023-01-25 at 09 42 28](https://user-images.githubusercontent.com/113189967/214517588-1dc4a3fd-1485-4204-8b68-f103836e28a4.gif)

![Recording 2023-01-25 at 09 46 32](https://user-images.githubusercontent.com/113189967/214518840-06ee6d2d-c895-4dd3-a9d9-6d7b81141ebb.gif)

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
~- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
