### PR TITLE
Add "Show in Dependency-Graph" Button in "Affected Projects" List

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -520,7 +520,8 @@
     "version_distance_major": "major",
     "version_distance_minor": "minor",
     "version_distance_patch": "patch",
-    "version_distance_tooltip": "Specify the difference between version numbers, or empty to ignore"
+    "version_distance_tooltip": "Specify the difference between version numbers, or empty to ignore",
+    "matrix": "Matrix"
   },
   "admin": {
     "configuration": "Configuration",

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -130,6 +130,21 @@ function configRoutes() {
           }
         },
         {
+          path: 'projects/:uuid/findings/:affectedComponent/:vulnerability',
+          name: 'Project Finding Lookup',
+          props: (route) => ( {
+            uuid: route.params.uuid,
+            affectedComponent: route.params.componentUuid,
+            vulnerability: route.params.vulnerability
+          } ),
+          component: Project,
+          meta: {
+            i18n: 'message.projects',
+            sectionPath: '/projects',
+            permission: 'VIEW_PORTFOLIO'
+          }
+        },
+        {
           path: 'components',
           name: 'Component Lookup',
           component: ComponentSearch,

--- a/src/views/portfolio/projects/ProjectFindings.vue
+++ b/src/views/portfolio/projects/ProjectFindings.vue
@@ -216,6 +216,12 @@ import common from "../../../shared/common";
             formatter(value, row, index) {
               return value === true ? '<i class="fa fa-check-square-o" />' : "";
             },
+          },
+          {
+            title: this.$t('message.matrix'),
+            field: "matrix",
+            sortable: true,
+            visible: false
           }
         ],
         data: [],
@@ -233,6 +239,7 @@ import common from "../../../shared/common";
           pageSize: (localStorage && localStorage.getItem("ProjectFindingsPageSize") !== null) ? Number(localStorage.getItem("ProjectFindingsPageSize")) : 10,
           sortName: (localStorage && localStorage.getItem("ProjectFindingsSortName") !== null) ? localStorage.getItem("ProjectFindingsSortName") : undefined,
           sortOrder: (localStorage && localStorage.getItem("ProjectFindingsSortOrder") !== null) ? localStorage.getItem("ProjectFindingsSortOrder") : undefined,
+          searchText: (this.$route.params.affectedComponent && this.$route.params.vulnerability) ? this.$route.params.uuid + ":" + this.$route.params.affectedComponent + ":" + this.$route.params.vulnerability : undefined,
           icons: {
             detailOpen: 'fa-fw fa-angle-right',
             detailClose: 'fa-fw fa-angle-down',
@@ -558,6 +565,9 @@ import common from "../../../shared/common";
       tableLoaded: function(data) {
         loadUserPreferencesForBootstrapTable(this, "ProjectFindings", this.$refs.table.columns);
         this.$emit('total', data.total);
+        if (this.$route.params.affectedComponent && this.$route.params.vulnerability) {
+          this.$refs.table.expandRow(0);
+        }
       },
       initializeTooltips: function () {
         $('[data-toggle="tooltip"]').tooltip({

--- a/src/views/portfolio/vulnerabilities/AffectedProjects.vue
+++ b/src/views/portfolio/vulnerabilities/AffectedProjects.vue
@@ -16,7 +16,8 @@
     mixins: [permissionsMixin],
     props: {
       source: String,
-      vulnId: String
+      vulnId: String,
+      vulnerability: String
     },
     data() {
       return {
@@ -26,7 +27,7 @@
             field: "name",
             sortable: true,
             formatter: (value, row, index) => {
-              let url = xssFilters.uriInUnQuotedAttr("../../../projects/" + row.uuid);
+              let url = xssFilters.uriInUnQuotedAttr("../../../projects/" + row.uuid + "/findings/" + row.affectedComponent + "/" + this.vulnerability);
               let dependencyGraphUrl = xssFilters.uriInUnQuotedAttr("../../../projects/" + row.uuid + "/dependencyGraph/" + row.affectedComponent)
               return row.directDependencies ? `<a href="${dependencyGraphUrl}"<i class="fa fa-sitemap" aria-hidden="true" style="float:right; padding-top: 4px; cursor:pointer" data-toggle="tooltip" data-placement="bottom" title="Show in dependency graph"></i></a> ` + `<a href="${url}">${xssFilters.inHTMLData(value)}</a>` : `<a href="${url}">${xssFilters.inHTMLData(value)}</a>`;
             }

--- a/src/views/portfolio/vulnerabilities/AffectedProjects.vue
+++ b/src/views/portfolio/vulnerabilities/AffectedProjects.vue
@@ -25,9 +25,10 @@
             title: this.$t('message.name'),
             field: "name",
             sortable: true,
-            formatter(value, row, index) {
+            formatter: (value, row, index) => {
               let url = xssFilters.uriInUnQuotedAttr("../../../projects/" + row.uuid);
-              return `<a href="${url}">${xssFilters.inHTMLData(value)}</a>`;
+              let dependencyGraphUrl = xssFilters.uriInUnQuotedAttr("../../../projects/" + row.uuid + "/dependencyGraph/" + row.affectedComponent)
+              return row.directDependencies ? `<a href="${dependencyGraphUrl}"<i class="fa fa-sitemap" aria-hidden="true" style="float:right; padding-top: 4px; cursor:pointer" data-toggle="tooltip" data-placement="bottom" title="Show in dependency graph"></i></a> ` + `<a href="${url}">${xssFilters.inHTMLData(value)}</a>` : `<a href="${url}">${xssFilters.inHTMLData(value)}</a>`;
             }
           },
           {

--- a/src/views/portfolio/vulnerabilities/Vulnerability.vue
+++ b/src/views/portfolio/vulnerabilities/Vulnerability.vue
@@ -140,7 +140,7 @@
       </b-tab>
       <b-tab ref="affectedprojects" v-if="isPermitted(PERMISSIONS.VIEW_VULNERABILITY)" @click="routeTo('affectedProjects')">
         <template v-slot:title><i class="fa fa-tasks"></i> {{ $t('message.affected_projects') }} <b-badge variant="tab-total">{{ totalAffectedProjects }}</b-badge></template>
-        <affected-projects :key="this.uuid" :source="source" :vulnId="vulnId" v-on:total="totalAffectedProjects = $event" />
+        <affected-projects v-if="this.vulnerability.uuid" :key="this.uuid" :vulnerability="vulnerability.uuid" :source="source" :vulnId="vulnId" v-on:total="totalAffectedProjects = $event" />
       </b-tab>
     </b-tabs>
   <vulnerability-details-modal :vulnProp="clonedVulnerability" v-on:vulnerabilityUpdated="syncVulnerabilityFields"/>


### PR DESCRIPTION
### Description

This PR adds the `Show in Dependency-Graph` button to the every project in the `Affected Projects` tab of a vulnerability, but only if the affected project has a dependency graph.
Clicking the button redirects the user to the projects dependency graph and highlights the affected component.

Clicking on the project link in a vulnerabilities' `Affected Projects` tab opens the project's `Audit Vulnerabilities` tab, showing only the expanded finding


### Addressed Issue

533

### Additional Details

![image](https://github.com/DependencyTrack/frontend/assets/113189967/c33d4636-b330-4510-a4e1-4ee63b770d92)


The redirect to a project's `Audit Vulnerabilities` tab works by opening a specific URL and searching for the matrix of a finding.
By adding a hidden `Matrix` column to the table, the wanted finding can be filtered and expanded by searching for it's matrix.
- URL Format: `.../projects/<projectUUID>/findings/<affectedComponentUUID>/<vulnerabilityUUID>`
- Matrix Format: `<projectUUID>:<affectedComponentUUID>:<vulnerabilityUUID>`

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
~- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
