### PR TITLE
Add "Show in Dependency-Graph" Button in "Component Search"

### DIFF
--- a/src/views/portfolio/components/ComponentSearch.vue
+++ b/src/views/portfolio/components/ComponentSearch.vue
@@ -155,7 +155,8 @@
             sortable: true,
             formatter(value, row, index) {
               let url = xssFilters.uriInUnQuotedAttr("../components/" + row.uuid);
-              return `<a href="${url}">${xssFilters.inHTMLData(value)}</a>`;
+              let dependencyGraphUrl = xssFilters.uriInUnQuotedAttr("../../../projects/" + row.project.uuid + "/dependencyGraph/" + row.uuid)
+              return row.project.directDependencies ? `<a href="${dependencyGraphUrl}"<i class="fa fa-sitemap" aria-hidden="true" style="float:right; padding-top: 4px; cursor:pointer" data-toggle="tooltip" data-placement="bottom" title="Show in dependency graph"></i></a> ` + `<a href="${url}">${xssFilters.inHTMLData(value)}</a>` : `<a href="${url}">${xssFilters.inHTMLData(value)}</a>`;
             }
           },
           {


### PR DESCRIPTION
### Description

This PR adds the `Show in Dependency-Graph` button to the every component in the `Component Search`, but only if the corresponding project has a dependency graph.
Clicking the button redirects the user to the projects dependency graph and highlights the component.

### Addressed Issue

543

### Additional Details

![image](https://github.com/DependencyTrack/frontend/assets/113189967/757e07e8-f1ed-40e2-8382-14a86f43fe84)

### Checklist

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/master/CONTRIBUTING.md#pull-requests)
~- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
